### PR TITLE
Add vscode group to video and render group

### DIFF
--- a/.devcontainer/amd64/devcontainer.json
+++ b/.devcontainer/amd64/devcontainer.json
@@ -9,7 +9,9 @@
     "--volume=/sys:/sys",
     "--volume=/etc/timezone:/etc/timezone",
     "--ipc=host",
-    "--shm-size=2g"
+    "--shm-size=2g",
+    "--group-add=video",
+    "--group-add=render"
   ],
   "mounts": [
     "source=${env:SSH_AUTH_SOCK},target=/ssh-agent,type=bind",

--- a/.devcontainer/jetson/devcontainer.json
+++ b/.devcontainer/jetson/devcontainer.json
@@ -11,7 +11,9 @@
     "--runtime=nvidia",
     "--gpus=all",
     "--ipc=host",
-    "--shm-size=2g"
+    "--shm-size=2g",
+    "--group-add=video",
+    "--group-add=render"
   ],
   "mounts": [
     "source=${env:SSH_AUTH_SOCK},target=/ssh-agent,type=bind",


### PR DESCRIPTION
Adding the vscode group to connect into the native computer's video and render group fixes one of the problems in the way of trying to use rviz2 within the container and using the gpu within the container. 

Specifically, it eliminated these messages when trying to run rviz2 or nvidia-smi or any gpu action:
```
libnvrm_gpu.so: NvRmGpuLibOpen failed, error=196626
NvRmMemInitNvmap failed with Permission denied
356: Memory Manager Not supported

NvRmMemMgrInit failed error type: 196626
```