### PR TITLE
Rover 401

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,9 @@ RUN if ! pkg-config --exists opencv4; then \
             -D BUILD_EXAMPLES=OFF \
             -D BUILD_TESTS=OFF \
             -D BUILD_PERF_TESTS=OFF \
+            -D WITH_QT=OFF \
+            -D WITH_GTK=OFF \
+            -D WITH_GTK_2_X=OFF \
             /opt/opencv && \
       make -j"$(nproc)" && make install; \
     else \

--- a/src/HW-Devices/science_sensors/science_sensors/panoramic.py
+++ b/src/HW-Devices/science_sensors/science_sensors/panoramic.py
@@ -78,7 +78,8 @@ class PanoramicNode(Node):
         rclpy.spin_until_future_complete(self, future)
 
         result = future.result()
-        if result is None:
+
+        if result is None or not result.success or len(result.image.data) == 0:
             self.get_logger().error("Failed to capture image")
             return None
 

--- a/src/HW-Devices/science_sensors/science_sensors/panoramic.py
+++ b/src/HW-Devices/science_sensors/science_sensors/panoramic.py
@@ -8,6 +8,7 @@ from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
 from rclpy.executors import MultiThreadedExecutor
 from interfaces.srv import MoveServo
 from interfaces.srv import VideoCapture
+from threading import Event
 
 
 class PanoramicNode(Node):
@@ -74,8 +75,20 @@ class PanoramicNode(Node):
             return
         request = VideoCapture.Request()
         request.source = self.camera_name
+        # Use an Event to wait for the async call to complete
+        # Using ros2 executor blocking calls creates deadlock after first call
+        event = Event()
+
+        def done_callback(future):
+            nonlocal event
+            event.set()
+
         future = self.video_cli.call_async(request)
-        rclpy.spin_until_future_complete(self, future)
+        future.add_done_callback(done_callback)
+        event.wait(10)  # wait for max 10 seconds
+        if not future.done():
+            self.get_logger().error("Video capture service call timed out")
+            return None
 
         result = future.result()
 


### PR DESCRIPTION
This pull request mainly addresses improvements to the image capture process in the `PanoramicNode` by replacing blocking service calls with a safer asynchronous approach. It also updates the OpenCV build configuration in the Dockerfile to reduce dependencies.

**Image capture improvements:**

* Replaced the blocking `rclpy.spin_until_future_complete` call in `PanoramicNode.capture_image` with an `Event` and a done callback to avoid deadlocks, ensuring the function waits up to 10 seconds for the async service call to complete. Added error handling for timeouts and failed captures.
* Imported `Event` from `threading` in `panoramic.py` to support the new async handling.

**Docker build optimization:**

* Updated the OpenCV build process in the `Dockerfile` to explicitly disable Qt and GTK dependencies by adding `-D WITH_QT=OFF`, `-D WITH_GTK=OFF`, and `-D WITH_GTK_2_X=OFF` to the CMake configuration.