### PR TITLE
rviz2 to within docker for jetson devcontainer.json

### DIFF
--- a/.devcontainer/jetson/devcontainer.json
+++ b/.devcontainer/jetson/devcontainer.json
@@ -17,12 +17,15 @@
   ],
   "mounts": [
     "source=${env:SSH_AUTH_SOCK},target=/ssh-agent,type=bind",
-    "source=${env:HOME}/.gitconfig,target=/home/vscode/.gitconfig,type=bind,consistency=cached"
+    "source=${env:HOME}/.gitconfig,target=/home/vscode/.gitconfig,type=bind,consistency=cached",
+    "source=/tmp/.X11-unix,target=/tmp/.X11-unix,type=bind",
+    "source=${env:HOME}/.Xauthority,target=/home/vscode/.Xauthority,type=bind"
   ],
   "containerEnv": {
     "SSH_AUTH_SOCK": "/ssh-agent",
     "NVIDIA_VISIBLE_DEVICES": "all",
-    "NVIDIA_DRIVER_CAPABILITIES": "all"
+    "NVIDIA_DRIVER_CAPABILITIES": "all",
+    "DISPLAY": "unix:0"
   },
   "remoteUser": "vscode",
   "containerUser": "vscode",


### PR DESCRIPTION
I got rviz2 working on my jetson orin nano using this changed devcontainer.json. 

On my jetson, I have to type export DISPLAY=unix:1 to make it work. I made the devcontainer.json set it to unix:0 because I believe that is the more default expected result, but if it isn't we should change the devcontainer.json set it to unix:1. I know my jetson is unix:1 by running this is seeing X1 not X0:
```
$ ls /tmp/.X11-unix
X1
```

For now I haven't touched the other ones because I can't test if I would break them and I don't want to do that while new people are using them.

I did have to do some devops on my jetson to make this work because it relies on X11 not wayland and wayland is the default for jetson. I tried briefly to make the devcontainer.json work with wayland but it's far more difficult than X11 and not worth it I think. I had to run this `sudo apt install xorg openbox` to get X11 installed on my jetson. Then I also had to run this: `sudo chown $USER:$USER $XAUTHORITY && ln -s $XAUTHORITY ~/.Xauthority && chmod 644 ~/.Xauthority` to make sure the .Xauthority is placed in the correct place. There was also some steps about starting a X11 server temporarily with `startx` if this returns nothing `ps aux | grep Xorg` but I didn't need to do that.

@ConnorNeed  I also have a dilemma where the mount that binds the .Xauthority into the docker container will cause the container to fail to launch if the .Xauthority file doesn't exist on the native filesystem, that would be bad. One option is a small setup script everyone has to run that places a temporary file in place of the .Xauthority for people who don't care about rviz or X11.

