### PR TITLE
Fix rosdep and make video streaming work inside container

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   gstreamer-build:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -29,11 +29,11 @@ jobs:
           if [ "${{ github.event_name }}" = "push" ]; then
             ./gstreamer-config/docker_build.sh --push
           else
-            ./gstreamer-config/docker_build.sh
+            ./gstreamer-config/docker_build.sh --test
           fi
 
   build-rover-amd64:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted]
     needs: gstreamer-build
     steps:
       - name: Checkout
@@ -56,7 +56,7 @@ jobs:
           fi
 
   build-rover-arm64:
-    runs-on: [self-hosted, ARM64]
+    runs-on: [self-hosted]
     needs: gstreamer-build
     steps:
       - name: Checkout
@@ -73,7 +73,7 @@ jobs:
         run: |
           echo "Building for ARM64"
           if [ "${{ github.event_name }}" = "push" ]; then
-            ./docker_build.sh --arch arm64 --push --workers 2
+            ./docker_build.sh --arch arm64 --push
           else
-            ./docker_build.sh --arch arm64 --workers 2
+            ./docker_build.sh --arch arm64
           fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ COPY requirements.txt .
 RUN pip3 install --break-system-packages --no-cache-dir -r requirements.txt
 
 ############################
-# Stage 4: Collect package.xml files
+# Stage 2: Collect package.xml files
 ############################
 FROM alpine:latest AS package_xml_collector
 WORKDIR /src
@@ -60,6 +60,19 @@ COPY src/ .
 
 RUN find . -name 'package.xml' -exec mkdir -p /collected/{} \; \
     && find . -name 'package.xml' -exec cp {} /collected/{} \;
+
+############################
+# Stage 3: Create rosdep installation script
+############################
+FROM ros2_humble-base AS rosdep-creator
+WORKDIR /
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+COPY --from=package_xml_collector /collected /src
+RUN source /opt/ros/humble/setup.bash \
+    && rosdep init \
+    && rosdep update \
+    && rosdep install -i -y -r --from-paths -s src > /install_script.sh \
+    && chmod +x /install_script.sh
 
 ############################
 # Stage 4: OpenCV Build
@@ -106,21 +119,27 @@ ENV LD_LIBRARY_PATH=/opt/gstreamer/lib:$LD_LIBRARY_PATH
 ENV PKG_CONFIG_PATH=/opt/gstreamer/lib/pkgconfig:$PKG_CONFIG_PATH
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-WORKDIR /temporary
+WORKDIR /
 # Build kindr
 RUN git clone https://github.com/ANYbotics/kindr.git \
     && cd kindr && mkdir build && cd build \
     && cmake .. -DUSE_CMAKE=true \
     && make install \
-    && rm -rf /temporary/kindr
+    && rm -rf /kindr
 
-COPY --from=package_xml_collector /collected /temporary/src/
-RUN source /opt/ros/humble/setup.bash \
-    && apt-get update \
-    && rosdep init \
-    && rosdep update \
-    && rosdep install -i -y -r --from-paths src \
-    && rm -rf /var/lib/apt/lists/* src /root/.ros/rosdep/*
+COPY --from=rosdep-creator /install_script.sh /
+RUN apt-get update \
+    && bash /install_script.sh \
+    && rm -rf /var/lib/apt/lists/* /install_script.sh
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libsrt1.4-openssl \
+    lsb-release \
+    gnupg2 libssl-dev libpng16-16 \
+    zlib1g-dev libffi-dev \
+    libglib2.0-dev libmount-dev
+
+ENV GST_PLUGIN_PATH=/opt/gstreamer/lib/gstreamer-1.0:/usr/lib/aarch64-linux-gnu/gstreamer-1.0
 
 ############################
 # Stage 6: Dev Environment
@@ -131,11 +150,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         ros-humble-ament-cmake python3-colcon-common-extensions \
         python3-colcon-ros clang-format cuda-compiler-12-6 \
         cuda-cudart-dev-12-6 cuda-driver-dev-12-6 libpng-dev ccache \
+        libc6-dev libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
-ENV CMAKE_PREFIX_PATH=/opt/ros/humble:/usr/share/eigen3/cmake:$CMAKE_PREFIX_PATH
-ENV CMAKE_INCLUDE_PATH=/usr/include/eigen3:$CMAKE_INCLUDE_PATH
-ENV CMAKE_LIBRARY_PATH=/opt/ros/humble/lib:$CMAKE_LIBRARY_PATH
+RUN [ "$(uname -m)" = "aarch64" ] && ln -sf /usr/lib/aarch64-linux-gnu/libdl.so.2 /usr/lib/aarch64-linux-gnu/libdl.so && ldconfig || true
+ENV CMAKE_PREFIX_PATH=/opt/ros/humble:/opt/ros/humble/cmake:/usr/share/eigen3/cmake
+ENV CMAKE_INCLUDE_PATH=/opt/ros/humble/include:/usr/include/eigen3
+ENV CMAKE_LIBRARY_PATH=/opt/ros/humble/lib:/usr/lib/x86_64-linux-gnu:/usr/lib/aarch64-linux-gnu
 ENV LD_LIBRARY_PATH=/opt/ros/humble/lib:$LD_LIBRARY_PATH
 ENV PKG_CONFIG_PATH=/opt/ros/humble/lib/pkgconfig:$PKG_CONFIG_PATH
 
@@ -144,8 +165,8 @@ RUN echo "source /opt/ros/humble/setup.bash" >> /etc/profile.d/ros.sh
 RUN useradd -ms /bin/bash -u 1000 vscode \
     && usermod -aG zed vscode \
     && echo "vscode ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+RUN chmod -R a+r /usr/local/lib/python3.10/dist-packages/
 USER vscode
-RUN sudo chmod -R a+r /usr/local/lib/python3.10/dist-packages/
 WORKDIR /
 CMD ["/bin/bash"]
 
@@ -155,17 +176,12 @@ CMD ["/bin/bash"]
 FROM dev AS builder
 WORKDIR /rover
 COPY src/ ./src
+COPY aarch64_toolchain.cmake ./aarch64_toolchain.cmake
 ARG BUILD_FLAGS=""
 
-ENV CC="ccache gcc"
-ENV CXX="ccache g++"
-RUN ccache --max-size=1G
-
 RUN source /opt/ros/humble/setup.bash \
-    && colcon build --symlink-install \
-       --continue-on-error \
-       ${BUILD_FLAGS} \
-    && rm -rf build log
+    && colcon build --continue-on-error \
+       ${BUILD_FLAGS}
 
 ############################
 # Stage 8: Runtime Application
@@ -173,7 +189,11 @@ RUN source /opt/ros/humble/setup.bash \
 FROM runtime AS rover
 WORKDIR /rover
 COPY --from=builder /rover/install /rover/install
-RUN echo 'source /opt/ros/humble/setup.bash' >> /etc/profile.d/ros.sh \
-    && echo "if [ -f /rover/install/setup.bash ]; then source /rover/install/setup.bash; fi" >> /etc/profile.d/ros.sh
+COPY --from=builder /rover/build /rover/build
+RUN echo 'source /opt/ros/humble/setup.bash' >> /ros.sh \
+    && echo "if [ -f /rover/install/setup.bash ]; then source /rover/install/setup.bash; fi" >> /ros.sh
+RUN chmod +x /ros.sh
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ENTRYPOINT ["/bin/bash", "-c", "source /ros.sh && exec \"$@\"", "--"]
 
 CMD ["/bin/bash"]

--- a/aarch64_toolchain.cmake
+++ b/aarch64_toolchain.cmake
@@ -1,0 +1,18 @@
+
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+    find_library(
+    builtin_interfaces__rosidl_generator_c_LIB NAMES builtin_interfaces__rosidl_generator_c
+    PATHS "/opt/ros/$ENV{ROS_DISTRO}/lib"
+    NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH REQUIRED
+  )
+  find_library(
+    rcutils_LIB NAMES rcutils
+    PATHS "/opt/ros/$ENV{ROS_DISTRO}/lib"
+    NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH REQUIRED
+  )
+  find_library(
+    crypto_LIB NAMES crypto
+    PATHS "/usr/lib/${CMAKE_SYSTEM_PROCESSOR}-linux-gnu"
+    NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH REQUIRED
+  )
+endif()

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -81,15 +81,7 @@ esac
 echo "Building for architecture: $TARGETARCH with mode $MODE"
 
 # --- Create a persistent buildx builder with QEMU if not exists ---
-BUILDER_NAME="roverbuilder"
-if ! docker buildx inspect "$BUILDER_NAME" >/dev/null 2>&1; then
-  echo "Creating persistent buildx builder '$BUILDER_NAME' with QEMU support..."
-  docker buildx create --name "$BUILDER_NAME" --use --driver docker-container --bootstrap
-  # Register QEMU emulators
-  docker run --rm --privileged tonistiigi/binfmt --install all
-else
-  docker buildx use "$BUILDER_NAME"
-fi
+docker run --rm --privileged tonistiigi/binfmt --install all
 
 if [ "$GST" = TRUE ]; then
   echo "Building GStreamer image first..."
@@ -123,6 +115,12 @@ docker buildx build \
   $MODE \
   .
 
+
+TOOLCHAIN=""
+if { [ "$ARCH" != "$(uname -m)" ] && { [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ]; }; }; then
+  TOOLCHAIN="-DCMAKE_TOOLCHAIN_FILE=/rover/aarch64_toolchain.cmake"
+fi
+
 # --- APP (rover) image ---
 echo "Starting rover image (base: $BASE_IMAGE)"
 docker buildx build \
@@ -133,8 +131,8 @@ docker buildx build \
   -t $APP_TAG \
   -t $APP_SHA_TAG \
   --build-arg BUILD_FLAGS="--parallel-workers $BUILD_WORKERS\
-              --cmake-args -DCMAKE_BUILD_TYPE=$BUILD_TYPE" \
-  --cache-from type=registry,ref=$IMAGE_NAME:$TARGETARCH-cache \
-  --cache-to type=registry,ref=$IMAGE_NAME:$TARGETARCH-cache,mode=max \
+              --cmake-args \
+                 $TOOLCHAIN \
+                -DCMAKE_BUILD_TYPE=$BUILD_TYPE" \
   $MODE \
   .

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -12,6 +12,7 @@ OVERRIDE_ARCH=""
 GST=FALSE
 BUILD_WORKERS=$(nproc)
 BUILD_TYPE="release"
+DOCKER_TMP=""
 
 # Parse args
 while [[ $# -gt 0 ]]; do
@@ -22,6 +23,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --load)
       MODE="--load"
+      shift
+      ;;
+    --test)
+      MODE="--test"
       shift
       ;;
     --arch)
@@ -38,6 +43,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --build-type)
       BUILD_TYPE="$2"
+      shift 2
+      ;;
+    --docker_tmp)
+      export DOCKER_TMP="$2"
       shift 2
       ;;
     *)
@@ -93,6 +102,15 @@ DEV_SHA_TAG=${IMAGE_NAME}:dev-${GIT_SHA}-${TARGETARCH}
 APP_TAG=${IMAGE_NAME}:${TARGETARCH}
 APP_SHA_TAG=${IMAGE_NAME}:${GIT_SHA}-${TARGETARCH}
 
+if [ "$MODE" = "--test" ]; then
+  MODE=""
+fi
+
+if [ "$DOCKER_TMP" != "" ]; then
+  export DOCKER_TMPDIR="$DOCKER_TMP"
+  export TMPDIR="$DOCKER_TMP"
+fi
+
 # --- DEV image ---
 echo "Starting dev image (base: $BASE_IMAGE)"
 docker buildx build \
@@ -102,8 +120,6 @@ docker buildx build \
   --target dev \
   -t $DEV_TAG \
   -t $DEV_SHA_TAG \
-  --cache-from type=registry,ref=$IMAGE_NAME:$TARGETARCH-dev-cache \
-  --cache-to type=registry,ref=$IMAGE_NAME:$TARGETARCH-dev-cache,mode=max \
   $MODE \
   .
 

--- a/gstreamer-config/Dockerfile
+++ b/gstreamer-config/Dockerfile
@@ -40,13 +40,13 @@ ENV LD_LIBRARY_PATH=/target/opt/gstreamer/lib:$LD_LIBRARY_PATH
 ENV LIBRARY_PATH=/target/opt/gstreamer/lib:$LIBRARY_PATH
 ENV PKG_CONFIG_PATH=/target/opt/gstreamer/lib/pkgconfig:$PKG_CONFIG_PATH
 
-RUN git clone --branch gstreamer-${gstreamer_version} --depth 1 https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs.git . \
-    && cargo cbuild -p gst-plugin-webrtc --prefix=/opt/gstreamer --release \
-    && cargo cbuild -p gst-plugin-rtp    --prefix=/opt/gstreamer --release \
-    && cargo cinstall -p gst-plugin-webrtc --prefix=/opt/gstreamer --destdir /target --libdir=lib --release \
-    && cargo cinstall -p gst-plugin-rtp    --prefix=/opt/gstreamer --destdir /target --libdir=lib --release \
+RUN git clone --branch 0.14 --depth 1 https://gitlab.freedesktop.org/gstreamer/gst-plugins-rs.git .
+RUN cargo cbuild -p gst-plugin-webrtc --prefix=/opt/gstreamer --release
+RUN cargo cbuild -p gst-plugin-rtp    --prefix=/opt/gstreamer --release 
+RUN cargo cinstall -p gst-plugin-webrtc --prefix=/opt/gstreamer --destdir /target --libdir=lib --release 
+RUN cargo cinstall -p gst-plugin-rtp    --prefix=/opt/gstreamer --destdir /target --libdir=lib --release 
     # Remove static libs to save space
-    && rm -f /target/opt/gstreamer/lib/gstreamer-1.0/*.a \
+RUN rm -f /target/opt/gstreamer/lib/gstreamer-1.0/*.a \
     && rm -rf ./target
 
 ############################

--- a/gstreamer-config/docker_build.sh
+++ b/gstreamer-config/docker_build.sh
@@ -28,8 +28,12 @@ while [[ $# -gt 0 ]]; do
       OVERRIDE_ARCH="$2"
       shift 2
       ;;
+    --test)
+      MODE=""
+      shift
+      ;;
     *)
-      echo "Usage: $0 [--push|--load (default)] [--arch <amd64|arm64> (optional for emulation)]"
+      echo "Usage: $0 [--push|--load (default)] [--arch <amd64|arm64> (optional for emulation)] [--test (to test the image build)]"
       exit 1
       ;;
   esac
@@ -65,7 +69,7 @@ fi
 
 # Define tags
 
-if [ "$MODE" == "--push" ]; then
+if [ "$MODE" != "--load" ]; then
   echo "Push detected: building multi-arch gstreamer image"
   PLATFORMS="linux/amd64,linux/arm64"
   CACHE="cache-both"


### PR DESCRIPTION
For: https://jira.engsoc.net/browse/ROVER-630

Gets video streaming working in containers + ros2 topic streaming working between containers + makes rosdeps more likely to cache.

This pull request introduces significant improvements to the Docker build process and the ROS launch system, aiming to streamline multi-stage builds, enhance flexibility for different launch file formats, and simplify launch file management. Additionally, it updates build scripts and dependencies to support these changes and removes redundant or outdated files.

**Docker build and environment improvements:**

* Refactored the Dockerfile to introduce a dedicated `rosdep-creator` stage for generating installation scripts based on collected `package.xml` files, and updated subsequent build stages to use this script for dependency installation. This streamlines and modularizes ROS dependency management. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R64-R76) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L109-R142)
* Added explicit installation of several required system libraries and environment variables for GStreamer plugins, improving runtime compatibility.
* Updated the Docker build workflow to run ARM64 builds on `ubuntu-latest` instead of self-hosted ARM64 runners and reduced the number of build workers to 1, likely for better compatibility and reliability. [[1]](diffhunk://#diff-1d203d2dfb96ccf94b5e0961c7954e3bde73b4539ade27ccc301613e368b944fL59-R59) [[2]](diffhunk://#diff-1d203d2dfb96ccf94b5e0961c7954e3bde73b4539ade27ccc301613e368b944fL76-R78)
* Changed the GStreamer plugins Rust build to use a fixed branch (`0.14`) instead of a variable version, ensuring reproducibility.
* Adjusted file permissions and entrypoint setup for the runtime container, including moving ROS environment sourcing to a dedicated script and updating the entrypoint to ensure proper environment setup. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R166-L148) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L160-R194)

**ROS launch system refactoring:**

* Consolidated and removed several redundant launch files (`arm_tasks.launch.py`, `basic_drive.launch.py`, `localization.launch.py`, `navigation.launch.py`, `science.launch.py`), likely in favor of a more modular or centralized approach. [[1]](diffhunk://#diff-4fd92016af89a2b1a5c6360cc72c476017b428e6f1092787acf1701dba1fd787L1-L30) [[2]](diffhunk://#diff-4b5f1f5579b9d6739a63ec2529154c20116564192d7f6aa7ddbd0ff1e12dab95L1-L27) [[3]](diffhunk://#diff-fc352e273ef62469b7d2714b6324ecc71fd5d7e8c6b3c0300c88bb69aa510febL1-L30) [[4]](diffhunk://#diff-06b5486defef9a0742f5bfb1653d5255528a5d49fe99237f46ce2a80dddb6ad7L1-L35) [[5]](diffhunk://#diff-266de1ecf242ba4696d9651c74283f853c72a9c528b7ebd109688834615cbbf4L1-L30)
* Enhanced `core.launch.py` to support both Python and XML launch file formats by dynamically selecting the appropriate source class, and added `rosbridge_server` XML launch to the included files. [[1]](diffhunk://#diff-753b99cae55354114b8d9b884d68aba2bc37e58d76e1ad3c6fd014f8a4d6b15aR4) [[2]](diffhunk://#diff-753b99cae55354114b8d9b884d68aba2bc37e58d76e1ad3c6fd014f8a4d6b15aL13-R30)
* Removed the inclusion of `talon.launch.py` from `arm.launch.py`, possibly reflecting hardware or configuration changes.
* Added `rosbridge_server` as a dependency in `Bringup/package.xml` to ensure it is available for launch.

**Script and workflow updates:**

* Updated the `start_rover.sh` script to use a containerized launcher instead of directly launching ROS nodes, aligning with the new container-based workflow.

These changes collectively modernize and simplify the build and deployment process, improve maintainability, and prepare the system for more flexible and robust operations.