### PR TITLE
fix: out of memory error

### DIFF
--- a/.devcontainer/amd64/devcontainer.json
+++ b/.devcontainer/amd64/devcontainer.json
@@ -9,7 +9,6 @@
     "--volume=/sys:/sys",
     "--volume=/etc/timezone:/etc/timezone",
     "--ipc=host",
-    "--shm-size=2g",
     "--group-add=video",
     "--group-add=render"
   ],

--- a/.devcontainer/jetson/devcontainer.json
+++ b/.devcontainer/jetson/devcontainer.json
@@ -11,7 +11,6 @@
     "--runtime=nvidia",
     "--gpus=all",
     "--ipc=host",
-    "--shm-size=2g",
     "--group-add=video",
     "--group-add=render"
   ],


### PR DESCRIPTION
I had initially added shared memory to the container for ros2 dds help but switched to setting ipc=host. This meant that this was just wasting RAM for no reason. This should help with building.