### PR TITLE
chore: mount keys directly to allow for ssh within remote dev container

### DIFF
--- a/.devcontainer/jetson/devcontainer.json
+++ b/.devcontainer/jetson/devcontainer.json
@@ -15,7 +15,7 @@
     "--group-add=render"
   ],
   "mounts": [
-    "source=${env:SSH_AUTH_SOCK},target=/ssh-agent,type=bind",
+    "source=${env:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached",
     "source=${env:HOME}/.gitconfig,target=/home/vscode/.gitconfig,type=bind,consistency=cached"
   ],
   "containerEnv": {


### PR DESCRIPTION
Mounting in the SSH agent doesn't seem to work when ssh'ed into another machine. Instead just bind in the ssh keys.