### PR TITLE
Microservice video streaming

### DIFF
--- a/gstreamer-config/Dockerfile
+++ b/gstreamer-config/Dockerfile
@@ -49,6 +49,17 @@ RUN cargo cinstall -p gst-plugin-rtp    --prefix=/opt/gstreamer --destdir /targe
 RUN rm -f /target/opt/gstreamer/lib/gstreamer-1.0/*.a \
     && rm -rf ./target
 
+RUN ln -s /target/opt/gstreamer /opt/gstreamer
+
+
+# Build Interpipe from source
+WORKDIR /interpipe
+RUN git clone --branch master --depth 1 https://github.com/RidgeRun/gst-interpipe.git . \
+    && meson setup builddir --prefix=/opt/gstreamer --libdir=lib --buildtype=release -Denable-gtk-doc=false\
+    && meson compile -C builddir \
+    && meson install -C builddir --destdir /target \
+    && rm -rf builddir
+
 ############################
 # Final Stage: Copy to final image
 ############################

--- a/src/Cameras/video_streaming/CMakeLists.txt
+++ b/src/Cameras/video_streaming/CMakeLists.txt
@@ -1,0 +1,83 @@
+cmake_minimum_required(VERSION 3.16)
+project(video_streaming LANGUAGES CXX)
+
+# ---- Build settings
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# ---- Dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_components REQUIRED)
+find_package(std_srvs REQUIRED)
+find_package(interfaces REQUIRED)
+find_package(PkgConfig REQUIRED)
+
+pkg_check_modules(GSTREAMER REQUIRED IMPORTED_TARGET gstreamer-1.0)
+pkg_check_modules(GST_APP REQUIRED IMPORTED_TARGET gstreamer-app-1.0)
+pkg_check_modules(GST_VIDEO REQUIRED IMPORTED_TARGET gstreamer-video-1.0)
+
+# ---- Targets
+add_library(${PROJECT_NAME} SHARED
+  src/base_video_node.cpp
+  src/input_node.cpp
+  src/detect_node.cpp
+  src/webrtc_node.cpp
+)
+
+include_directories(
+  include/${PROJECT_NAME}
+  ${GSTREAMER_INCLUDE_DIRS}
+  ${GST_APP_INCLUDE_DIRS}
+  ${GST_VIDEO_INCLUDE_DIRS}
+)
+
+target_link_directories(${PROJECT_NAME} PRIVATE ${GST_LIBRARY_DIRS})
+target_link_libraries(${PROJECT_NAME} 
+  PkgConfig::GSTREAMER
+  PkgConfig::GST_APP
+  PkgConfig::GST_VIDEO
+)
+ament_target_dependencies(${PROJECT_NAME}
+  rclcpp
+  rclcpp_components
+  interfaces
+  std_srvs
+)
+
+# If pkg-config provided extra compile flags (e.g., -D, -pthread)
+target_compile_options(${PROJECT_NAME} PRIVATE ${GST_CFLAGS_OTHER})
+
+# Register both composable nodes
+rclcpp_components_register_nodes(${PROJECT_NAME}
+  "InputNode"
+  "DetectNode"
+  "WebRtcNode"
+)
+
+# ---- Install
+install(
+  TARGETS ${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+install(
+  DIRECTORY include/
+  DESTINATION include/
+)
+
+install(DIRECTORY launch
+  DESTINATION share/${PROJECT_NAME}
+)
+install(DIRECTORY config
+  DESTINATION share/${PROJECT_NAME}
+)
+
+# ---- Export
+ament_export_include_directories(include/${PROJECT_NAME})
+ament_export_dependencies(rclcpp rclcpp_components)
+ament_export_libraries(${PROJECT_NAME})
+
+ament_package()

--- a/src/Cameras/video_streaming/README
+++ b/src/Cameras/video_streaming/README
@@ -1,8 +1,8 @@
 # Video Streaming
-This is currently under development. For now continue using th camera_streaming package.
+This is currently under development. For now continue using the camera_streaming package.
 
 ## Architecture:
-This package is broken down into ros2 components. Each component runs a gsteamer pipeline to preform some video processing task. Interpipe elements developed by RidgeRun are used to efficiently (no-copy) pass buffers between components. This requrires that all components that shae buffers are run inside the same process (Ros2 container).
+This package is broken down into ros2 components. Each component runs a GStreamer pipeline to perform some video processing task. Interpipe elements developed by RidgeRun are used to efficiently (no-copy) pass buffers between components. This requires that all components that share buffers are run inside the same process (Ros2 container).
 
 ## Components
 

--- a/src/Cameras/video_streaming/README
+++ b/src/Cameras/video_streaming/README
@@ -1,0 +1,31 @@
+# Video Streaming
+This is currently under development. For now continue using th camera_streaming package.
+
+## Architecture:
+This package is broken down into ros2 components. Each component runs a gsteamer pipeline to preform some video processing task. Interpipe elements developed by RidgeRun are used to efficiently (no-copy) pass buffers between components. This requrires that all components that shae buffers are run inside the same process (Ros2 container).
+
+## Components
+
+#### Input node
+Takes in video sources and controls which ones are composited and displayed on the output image.
+Inputs implemented:
+* [x] Video test source (videotestsrc element)
+* [x] V4l2 drivers (USB cams)
+* [ ] Static overlays
+* [ ] Ros2 image topics
+
+#### Detect node
+Runs object detection on the incoming video feed
+Detection implemented:
+* [ ] Aruco Tags
+* [ ] Hammer
+* [ ] Ice Pick
+
+#### WebRTC node
+This is the same method of video streaming we used in 2024/25. Easy use since it is compatible with browsers. Downside is that is was specifically made for the internet at large and has overhead that isn't needed for our use case. STATUS: Implemented
+
+#### Image capture
+Captures jpeg images and returns them on request using a ros2 service API. STATUS: Un-implemented
+
+#### SRT node
+Possible replacement for WebRTC node. Coming Soon. 

--- a/src/Cameras/video_streaming/config/cameras.yaml
+++ b/src/Cameras/video_streaming/config/cameras.yaml
@@ -1,0 +1,22 @@
+#Types: 0 for v4l2, 1 for test source, Other types are not supported yet
+
+input_node:
+  ros__parameters:
+    camera_name:
+    - "Drive"
+    - "EndEffector"
+    - "Bottom"
+    - "Test"
+    Drive:
+      path: "/dev/v4l/by-id/usb-Arducam_Arducam_B0495__USB3_2.3MP_-video-index0"
+      type: 0
+    EndEffector:
+      path: "/dev/v4l/by-id/usb-Sonix_Technology_Co.__Ltd._USB_2.0_Camera_SN5100-video-index0"
+      type: 0
+      encoded: true
+    Bottom:
+      path: "/dev/v4l/by-id/usb-HD_Camera_Manufacturer_USB_2.0_Camera-video-index0"
+      type: 0
+      encoded: true
+    Test:
+      type: 1

--- a/src/Cameras/video_streaming/include/video_streaming/base_video_node.hpp
+++ b/src/Cameras/video_streaming/include/video_streaming/base_video_node.hpp
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <atomic>
+#include <gst/app/gstappsink.h>
+#include <gst/gst.h>
+#include <mutex>
+#include <optional>
+#include <rclcpp/rclcpp.hpp>
+#include <string>
+#include <thread>
+
+class BaseVideoNode : public rclcpp::Node {
+public:
+  explicit BaseVideoNode(
+      const std::string name,
+      const rclcpp::NodeOptions &options = rclcpp::NodeOptions());
+  ~BaseVideoNode() override;
+
+protected:
+  // Convenience: look up elements by name after the pipeline is built.
+  // Returns new ref; caller must unref.
+  GstElement *get_element(const std::string &name) const;
+
+  // GStreamer pipeline owned by this node.
+  GstElement *pipeline_{nullptr};
+
+  // Subclass must construct and assign `pipeline_` (GST_IS_PIPELINE(pipeline_)
+  // must be true).
+  virtual bool create_pipeline() = 0;
+
+  virtual bool start_pipeline();
+
+  // Mutex to protect `pipeline_` access across threads
+  mutable std::mutex pipeline_mutex_;
+  static std::once_flag gst_init_once_flag_;
+};

--- a/src/Cameras/video_streaming/include/video_streaming/detect_node.hpp
+++ b/src/Cameras/video_streaming/include/video_streaming/detect_node.hpp
@@ -1,0 +1,12 @@
+#pragma once
+#include "base_video_node.hpp"
+
+class DetectNode : public BaseVideoNode {
+public:
+  explicit DetectNode(
+      const rclcpp::NodeOptions &options = rclcpp::NodeOptions());
+  ~DetectNode() override = default;
+
+protected:
+  bool create_pipeline() override;
+};

--- a/src/Cameras/video_streaming/include/video_streaming/input_node.hpp
+++ b/src/Cameras/video_streaming/include/video_streaming/input_node.hpp
@@ -1,0 +1,46 @@
+#pragma once
+#include "base_video_node.hpp"
+#include <interfaces/srv/get_cameras.hpp>
+#include <interfaces/srv/video_capture.hpp>
+#include <interfaces/srv/video_out.hpp>
+
+class InputNode : public BaseVideoNode {
+public:
+  explicit InputNode(
+      const rclcpp::NodeOptions &options = rclcpp::NodeOptions());
+  ~InputNode() override = default;
+
+protected:
+  enum class CameraType {
+    V4l2Src = 0, /**< V4L2 source */
+    TestSrc,     /**< Test source */
+    NetworkSrc,  /**< Network source */
+  };
+  bool create_pipeline() override;
+  void declare_parameters();
+
+  /**
+   * @brief Callback function to configure the video feed.
+   *
+   * @param request The request object containing video output parameters.
+   * @param response The response object to be populated with the result.
+   */
+  void
+  video_cb(const std::shared_ptr<interfaces::srv::VideoOut::Request> request,
+           std::shared_ptr<interfaces::srv::VideoOut::Response> response);
+
+  /**
+   * @brief Callback function to get available camera sources.
+   *
+   * @param request The request object (not used).
+   * @param response The response object to be populated with the camera
+   * sources.
+   */
+  void get_cameras_cb(
+      const std::shared_ptr<interfaces::srv::GetCameras::Request> request,
+      std::shared_ptr<interfaces::srv::GetCameras::Response> response);
+
+private:
+  std::map<std::string, size_t> source_map_;
+  rclcpp::Service<interfaces::srv::VideoOut>::SharedPtr video_service_;
+};

--- a/src/Cameras/video_streaming/include/video_streaming/webrtc_node.hpp
+++ b/src/Cameras/video_streaming/include/video_streaming/webrtc_node.hpp
@@ -1,0 +1,12 @@
+#pragma once
+#include "base_video_node.hpp"
+
+class WebRtcNode : public BaseVideoNode {
+public:
+  explicit WebRtcNode(
+      const rclcpp::NodeOptions &options = rclcpp::NodeOptions());
+  ~WebRtcNode() override = default;
+
+protected:
+  bool create_pipeline() override;
+};

--- a/src/Cameras/video_streaming/launch/video_streaming.launch.py
+++ b/src/Cameras/video_streaming/launch/video_streaming.launch.py
@@ -1,0 +1,51 @@
+import os
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch_ros.actions import ComposableNodeContainer, LoadComposableNodes
+from launch_ros.descriptions import ComposableNode
+
+
+def generate_launch_description():
+    config_dir = os.path.join(get_package_share_directory("video_streaming"), "config")
+
+    camera_params_file = os.path.join(config_dir, "cameras.yaml")
+    # Define each composable node
+    input_node = ComposableNode(
+        package="video_streaming",
+        plugin="InputNode",
+        name="input_node",
+        namespace="",
+        parameters=[camera_params_file],
+    )
+
+    detect_node = ComposableNode(
+        package="video_streaming",
+        plugin="DetectNode",
+        name="detect_node",
+        namespace="",
+        parameters=[],
+    )
+
+    streaming_node = ComposableNode(
+        package="video_streaming",
+        plugin="WebRtcNode",
+        name="streaming_node",
+        namespace="",
+        parameters=[],
+    )
+
+    # Create a container for all 3 components
+    container = ComposableNodeContainer(
+        name="video_streaming_container",
+        namespace="",
+        package="rclcpp_components",
+        executable="component_container_mt",
+        composable_node_descriptions=[
+            input_node,
+            detect_node,
+            streaming_node,
+        ],
+        output="screen",
+    )
+
+    return LaunchDescription([container])

--- a/src/Cameras/video_streaming/launch/video_streaming.launch.py
+++ b/src/Cameras/video_streaming/launch/video_streaming.launch.py
@@ -1,7 +1,7 @@
 import os
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch_ros.actions import ComposableNodeContainer, LoadComposableNodes
+from launch_ros.actions import ComposableNodeContainer
 from launch_ros.descriptions import ComposableNode
 
 

--- a/src/Cameras/video_streaming/package.xml
+++ b/src/Cameras/video_streaming/package.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>video_streaming</name>
+  <version>0.0.0</version>
+  <description>TODO: Package description</description>
+  <maintainer email="connor.needham2015@gmail.com">connor</maintainer>
+  <license>TODO: License declaration</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <depend>rclcpp</depend>
+  <depend>interfaces</depend>
+  <depend>std_srvs</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/Cameras/video_streaming/src/base_video_node.cpp
+++ b/src/Cameras/video_streaming/src/base_video_node.cpp
@@ -50,26 +50,5 @@ bool BaseVideoNode::start_pipeline() {
     }
   }
   RCLCPP_INFO(get_logger(), "BaseVideoNode: pipeline started.");
-  if (!pipeline_ || !GST_IS_PIPELINE(pipeline_)) {
-    RCLCPP_ERROR(get_logger(), "Invalid pipeline constructed by subclass.");
-    if (pipeline_) {
-      gst_object_unref(pipeline_);
-      pipeline_ = nullptr;
-    }
-    throw std::runtime_error("BaseVideoNode: invalid pipeline");
-  }
-  {
-    std::lock_guard<std::mutex> lock(pipeline_mutex_);
-    if (gst_element_set_state(pipeline_, GST_STATE_PLAYING) ==
-        GST_STATE_CHANGE_FAILURE) {
-      RCLCPP_ERROR(get_logger(), "Failed to set pipeline to PLAYING.");
-      gst_element_set_state(pipeline_, GST_STATE_NULL);
-      gst_object_unref(pipeline_);
-      pipeline_ = nullptr;
-      throw std::runtime_error("BaseVideoNode: PLAYING failed");
-    }
-  }
-
-  RCLCPP_INFO(get_logger(), "BaseVideoNode: pipeline started.");
   return true;
 }

--- a/src/Cameras/video_streaming/src/base_video_node.cpp
+++ b/src/Cameras/video_streaming/src/base_video_node.cpp
@@ -1,0 +1,75 @@
+#include "base_video_node.hpp"
+#include <stdexcept>
+
+// Define the static once_flag
+std::once_flag BaseVideoNode::gst_init_once_flag_;
+
+BaseVideoNode::BaseVideoNode(const std::string name,
+                             const rclcpp::NodeOptions &options)
+    : rclcpp::Node(name, options) {
+  // Ensure GStreamer initialized once globally (thread-safe)
+  std::call_once(gst_init_once_flag_, []() { gst_init(nullptr, nullptr); });
+}
+
+BaseVideoNode::~BaseVideoNode() {
+  std::lock_guard<std::mutex> lock(pipeline_mutex_);
+  if (pipeline_) {
+    gst_element_set_state(pipeline_, GST_STATE_NULL);
+    gst_object_unref(pipeline_);
+    pipeline_ = nullptr;
+  }
+  RCLCPP_INFO(get_logger(), "BaseVideoNode: pipeline stopped and cleaned up.");
+}
+
+GstElement *BaseVideoNode::get_element(const std::string &name) const {
+  std::lock_guard<std::mutex> lock(pipeline_mutex_);
+  if (!pipeline_)
+    return nullptr;
+  return gst_bin_get_by_name(GST_BIN(pipeline_), name.c_str());
+}
+
+bool BaseVideoNode::start_pipeline() {
+  // Create pipeline
+  if (!create_pipeline() || !pipeline_ || !GST_IS_PIPELINE(pipeline_)) {
+    RCLCPP_ERROR(get_logger(), "Invalid pipeline constructed by subclass.");
+    if (pipeline_) {
+      gst_object_unref(pipeline_);
+      pipeline_ = nullptr;
+    }
+    throw std::runtime_error("BaseVideoNode: invalid pipeline");
+  }
+  {
+    std::lock_guard<std::mutex> lock(pipeline_mutex_);
+    if (gst_element_set_state(pipeline_, GST_STATE_PLAYING) ==
+        GST_STATE_CHANGE_FAILURE) {
+      RCLCPP_ERROR(get_logger(), "Failed to set pipeline to PLAYING.");
+      gst_element_set_state(pipeline_, GST_STATE_NULL);
+      gst_object_unref(pipeline_);
+      pipeline_ = nullptr;
+      throw std::runtime_error("BaseVideoNode: PLAYING failed");
+    }
+  }
+  RCLCPP_INFO(get_logger(), "BaseVideoNode: pipeline started.");
+  if (!pipeline_ || !GST_IS_PIPELINE(pipeline_)) {
+    RCLCPP_ERROR(get_logger(), "Invalid pipeline constructed by subclass.");
+    if (pipeline_) {
+      gst_object_unref(pipeline_);
+      pipeline_ = nullptr;
+    }
+    throw std::runtime_error("BaseVideoNode: invalid pipeline");
+  }
+  {
+    std::lock_guard<std::mutex> lock(pipeline_mutex_);
+    if (gst_element_set_state(pipeline_, GST_STATE_PLAYING) ==
+        GST_STATE_CHANGE_FAILURE) {
+      RCLCPP_ERROR(get_logger(), "Failed to set pipeline to PLAYING.");
+      gst_element_set_state(pipeline_, GST_STATE_NULL);
+      gst_object_unref(pipeline_);
+      pipeline_ = nullptr;
+      throw std::runtime_error("BaseVideoNode: PLAYING failed");
+    }
+  }
+
+  RCLCPP_INFO(get_logger(), "BaseVideoNode: pipeline started.");
+  return true;
+}

--- a/src/Cameras/video_streaming/src/detect_node.cpp
+++ b/src/Cameras/video_streaming/src/detect_node.cpp
@@ -1,0 +1,36 @@
+#include "detect_node.hpp"
+#include <rclcpp_components/register_node_macro.hpp>
+
+DetectNode::DetectNode(const rclcpp::NodeOptions &options)
+    : BaseVideoNode("detect_node", options) {
+  RCLCPP_INFO(this->get_logger(), "DetectNode constructed.");
+  start_pipeline();
+}
+
+bool DetectNode::create_pipeline() {
+  // Currently just a placeholder pipeline that receives video via interpipesrc
+  const char *desc =
+      "interpipesrc listen-to=input is-live=true allow-renegotiation=true ! "
+      "identity silent=true ! "
+      "interpipesink name=detect";
+
+  GError *err = nullptr;
+  GstElement *p = gst_parse_launch(desc, &err);
+  if (err || !p) {
+    RCLCPP_ERROR(this->get_logger(), "gst_parse_launch failed: %s",
+                 err ? err->message : "unknown");
+    if (err)
+      g_error_free(err);
+    return false;
+  }
+  if (!GST_IS_PIPELINE(p)) {
+    RCLCPP_ERROR(this->get_logger(), "Parsed element is not a pipeline.");
+    gst_object_unref(p);
+    return false;
+  }
+
+  pipeline_ = p;
+  return true;
+}
+
+RCLCPP_COMPONENTS_REGISTER_NODE(DetectNode)

--- a/src/Cameras/video_streaming/src/input_node.cpp
+++ b/src/Cameras/video_streaming/src/input_node.cpp
@@ -1,0 +1,172 @@
+#include "input_node.hpp"
+#include <filesystem>
+#include <rclcpp_components/register_node_macro.hpp>
+
+InputNode::InputNode(const rclcpp::NodeOptions &options)
+    : BaseVideoNode("input_node", options) {
+  RCLCPP_INFO(this->get_logger(), "InputNode constructed.");
+  declare_parameters();
+  video_service_ = this->create_service<interfaces::srv::VideoOut>(
+      "start_video", std::bind(&InputNode::video_cb, this,
+                               std::placeholders::_1, std::placeholders::_2));
+  start_pipeline();
+}
+
+void InputNode::declare_parameters() {
+  this->declare_parameter("out_width", 1280);
+  this->declare_parameter("out_height", 720);
+  this->declare_parameter("out_framerate", 30);
+  this->declare_parameter("camera_name", std::vector<std::string>());
+  std::vector<std::string> camera_name;
+  this->get_parameter("camera_name", camera_name);
+  for (const auto &name : camera_name) {
+    this->declare_parameter(name + ".path", std::string());
+    this->declare_parameter(name + ".type",
+                            static_cast<int>(CameraType::V4l2Src));
+    this->declare_parameter(name + ".encoded", false);
+  }
+}
+
+bool InputNode::create_pipeline() {
+  std::stringstream desc_stream;
+  size_t index = 0;
+  std::vector<std::string> camera_name;
+  this->get_parameter("camera_name", camera_name);
+  for (const auto &name : camera_name) {
+    std::string path;
+    this->get_parameter(name + ".path", path);
+    int type_int;
+    this->get_parameter(name + ".type", type_int);
+    CameraType type = static_cast<CameraType>(type_int);
+
+    if (type == CameraType::TestSrc) {
+      desc_stream << "videotestsrc is-live=true name=" << name << " ! ";
+    } else if (type == CameraType::V4l2Src) {
+      if (!std::filesystem::exists(path)) {
+        RCLCPP_ERROR(this->get_logger(), "Camera path does not exist: %s",
+                     path.c_str());
+        continue;
+      }
+      desc_stream << "v4l2src device=" << path << " name=" << name << " ! ";
+      bool encoded;
+      this->get_parameter(name + ".encoded", encoded);
+      if (encoded) {
+        desc_stream << "jpegdec ! ";
+      }
+    } else {
+      RCLCPP_WARN(this->get_logger(), "Unimplemented Type for camera: %s",
+                  name.c_str());
+      continue;
+    }
+    desc_stream << "nvvidconv ! compositor.sink_" << index << " ";
+    source_map_.emplace(name, index);
+    ++index;
+  }
+  desc_stream << "nvcompositor name=compositor sink_0::width="
+              << this->get_parameter("out_width").as_int() << " sink_0::height="
+              << this->get_parameter("out_height").as_int();
+  desc_stream << " ! nvvidconv ! video/x-raw,width="
+              << this->get_parameter("out_width").as_int()
+              << ",height=" << this->get_parameter("out_height").as_int()
+              << ",framerate=" << this->get_parameter("out_framerate").as_int()
+              << "/1 ! interpipesink name=input";
+
+  RCLCPP_INFO(this->get_logger(), "Pipeline description: %s",
+              desc_stream.str().c_str());
+  GError *err = nullptr;
+  GstElement *p = gst_parse_launch(desc_stream.str().c_str(), &err);
+  if (err || !p) {
+    RCLCPP_ERROR(this->get_logger(), "gst_parse_launch failed: %s",
+                 err ? err->message : "unknown");
+    if (err)
+      g_error_free(err);
+    return false;
+  }
+  if (!GST_IS_PIPELINE(p)) {
+    RCLCPP_ERROR(this->get_logger(), "Parsed element is not a pipeline.");
+    gst_object_unref(p);
+    return false;
+  }
+
+  pipeline_ = p;
+  return true;
+}
+
+void InputNode::video_cb(
+    const std::shared_ptr<interfaces::srv::VideoOut::Request> request,
+    std::shared_ptr<interfaces::srv::VideoOut::Response> response) {
+  if (!pipeline_) {
+    RCLCPP_ERROR(this->get_logger(), "Pipeline not initialized");
+    response->success = false;
+    return;
+  }
+  RCLCPP_INFO(this->get_logger(), "Recieved request");
+  {
+    std::lock_guard<std::mutex> lock(pipeline_mutex_);
+    gst_element_set_state(pipeline_, GST_STATE_PAUSED);
+  }
+
+  const auto total_height = this->get_parameter("out_height").as_int();
+  const auto total_width = this->get_parameter("out_width").as_int();
+
+  GstElement *compositor = get_element("compositor");
+
+  if (!compositor) {
+    RCLCPP_ERROR(this->get_logger(), "Failed to get compositor element");
+    response->success = false;
+    return;
+  }
+  for (size_t i = 0; i < source_map_.size(); ++i) {
+    std::string pad_name = "sink_" + std::to_string(i);
+    GstPad *pad = gst_element_get_static_pad(compositor, pad_name.c_str());
+    if (!pad) {
+      RCLCPP_ERROR(this->get_logger(), "Failed to get compositor pad: %s",
+                   pad_name.c_str());
+      response->success = false;
+      return;
+    }
+    g_object_set(G_OBJECT(pad), "alpha", 0, NULL);
+    gst_object_unref(pad);
+  }
+  size_t order = 0;
+  for (const auto &source : request->sources) {
+    const std::string &name = source.name;
+    const int height = source.height * total_height / 100;
+    const int width = source.width * total_width / 100;
+    const int origin_x = source.origin_x * total_width / 100;
+    const int origin_y = source.origin_y * total_height / 100;
+
+    auto iter = source_map_.find(name);
+    if (iter == source_map_.end()) {
+      RCLCPP_WARN(this->get_logger(), "%s: Could not find camera %s",
+                  __FUNCTION__, name.c_str());
+      continue;
+    }
+    const std::string pad_name = "sink_" + std::to_string(iter->second);
+    GstPad *pad = gst_element_get_static_pad(compositor, pad_name.c_str());
+    if (!pad) {
+      RCLCPP_ERROR(this->get_logger(), "Failed to get compositor pad: %s",
+                   pad_name.c_str());
+      response->success = false;
+      return;
+    }
+    g_object_set(G_OBJECT(pad), "xpos", origin_x, "ypos", origin_y, "zorder",
+                 order++, "alpha", 1.0, NULL);
+    gst_object_unref(pad);
+  }
+  gst_object_unref(compositor);
+  GstStateChangeReturn ret;
+  {
+    std::lock_guard<std::mutex> lock(pipeline_mutex_);
+    ret = gst_element_set_state(pipeline_, GST_STATE_PLAYING);
+  }
+  if (ret != GST_STATE_CHANGE_FAILURE) {
+    RCLCPP_INFO(this->get_logger(), "Pipeline started successfully");
+    response->success = true;
+  } else {
+    RCLCPP_ERROR(this->get_logger(), "Failed to start pipeline");
+    response->success = false;
+  }
+}
+
+RCLCPP_COMPONENTS_REGISTER_NODE(InputNode)

--- a/src/Cameras/video_streaming/src/input_node.cpp
+++ b/src/Cameras/video_streaming/src/input_node.cpp
@@ -100,7 +100,7 @@ void InputNode::video_cb(
     response->success = false;
     return;
   }
-  RCLCPP_INFO(this->get_logger(), "Recieved request");
+  RCLCPP_INFO(this->get_logger(), "Received request");
   {
     std::lock_guard<std::mutex> lock(pipeline_mutex_);
     gst_element_set_state(pipeline_, GST_STATE_PAUSED);

--- a/src/Cameras/video_streaming/src/webrtc_node.cpp
+++ b/src/Cameras/video_streaming/src/webrtc_node.cpp
@@ -1,0 +1,38 @@
+#include "webrtc_node.hpp"
+#include <rclcpp_components/register_node_macro.hpp>
+
+WebRtcNode::WebRtcNode(const rclcpp::NodeOptions &options)
+    : BaseVideoNode("webrtc_node", options) {
+  if (!start_pipeline()) {
+    RCLCPP_FATAL(get_logger(), "WebRtcNode: failed to start pipeline.");
+    throw std::runtime_error("WebRtcNode: pipeline start failed");
+  }
+  RCLCPP_INFO(get_logger(), "WebRtcNode constructed and pipeline started.");
+}
+
+bool WebRtcNode::create_pipeline() {
+  const char *desc = "interpipesrc listen-to=detect ! "
+                     "identity silent=true ! nvvidconv ! "
+                     "webrtcsink run-signalling-server=true "
+                     "video-caps=\"video/x-h265; video/x-h264\"";
+
+  GError *err = nullptr;
+  GstElement *p = gst_parse_launch(desc, &err);
+  if (err || !p) {
+    RCLCPP_ERROR(get_logger(), "gst_parse_launch failed: %s",
+                 err ? err->message : "unknown");
+    if (err)
+      g_error_free(err);
+    return false;
+  }
+  if (!GST_IS_PIPELINE(p)) {
+    RCLCPP_ERROR(get_logger(), "Parsed element is not a pipeline.");
+    gst_object_unref(p);
+    return false;
+  }
+
+  pipeline_ = p;
+  return true;
+}
+
+RCLCPP_COMPONENTS_REGISTER_NODE(WebRtcNode)


### PR DESCRIPTION
Instead of removing the camera_streaming package, I want to create a new package called video_streaming. Once video_streaming has all the same necessary functionality camera_streaming has we can remove camera_streaming and switch to using video_streaming for everything.

This pull request introduces a new ROS2 package, `video_streaming`, that provides a modular architecture for camera video streaming and processing using GStreamer pipelines and RidgeRun's Interpipe elements. The package is organized into composable nodes for input, detection, and WebRTC streaming, with configuration and launch files for flexible deployment. The most important changes are grouped below by theme.

**ROS2 Package Setup and Build System:**

* Added `video_streaming` ROS2 package with `package.xml` and CMake build system, specifying dependencies (`rclcpp`, `interfaces`, `std_srvs`, GStreamer libraries) and export settings. [[1]](diffhunk://#diff-cdef696f50729baf02594a8d3fd02bb330ee088178aa346e893da0ea7b982ee2R1-R18) [[2]](diffhunk://#diff-876abe7b19f2aad41bc5fa31b1b6e98cfb8cb0e40b4fc9bb0e02a4058ddd9c22R1-R83)

**Architecture and Components:**

* Added documentation (`README`) describing the package architecture, modular node design, and supported features for input sources, detection, and streaming.
* Added configuration file (`config/cameras.yaml`) for camera sources and parameters, supporting V4L2 and test sources.

**Composable Node Implementations:**

* Implemented core node classes: `BaseVideoNode`, `InputNode`, `DetectNode`, and `WebRtcNode` with header and source files. Each node manages its own GStreamer pipeline, with `InputNode` handling camera compositing and service APIs, `DetectNode` as a placeholder for future detection, and `WebRtcNode` streaming via WebRTC. [[1]](diffhunk://#diff-34d8fa5b63fbdd3396805cf1eec5dcfdd3e29677cef7ed6e77429a2416e2dd5aR1-R36) [[2]](diffhunk://#diff-d41143ba2f0e611c21c1c3a9a98fa73d6a4f2242b3c9f2a390f37c42782e2776R1-R46) [[3]](diffhunk://#diff-89ebb01aad9b96559265d1a37841a3755be87af332982845068753402109929eR1-R12) [[4]](diffhunk://#diff-a5e18e011b6b2cb63c25247bf3ecce635ec2f3e8b3a31aa65457e5f17fbd1f5eR1-R12) [[5]](diffhunk://#diff-84beb95e7174dc79f9d2f392b61f5c324191bee0af0d578380eef3465f530bdbR1-R75) [[6]](diffhunk://#diff-0332bc2e56ce010b825fbf46ef41b251e72495b66ff8cd31d1475acb7ef0c033R1-R172) [[7]](diffhunk://#diff-6477d079b79df5206dc9c1e8a5e860a03499ecff344298105e9ba5604aa95ce3R1-R36) [[8]](diffhunk://#diff-5836d836b39e59dac4b70aefd5f70a3805623a30bae5fe5374be8b00d0343204R1-R38)

**Launch and Configuration:**

* Added launch file (`launch/video_streaming.launch.py`) to deploy all three composable nodes in a container, loading camera configuration from YAML.

**Docker and Build Environment:**

* Updated `gstreamer-config/Dockerfile` to build and install RidgeRun's gst-interpipe plugin from source, and symlink GStreamer libraries for development.