### PR TITLE
Navigation tuning

### DIFF
--- a/src/Nav/localization/launch/ekf.launch.py
+++ b/src/Nav/localization/launch/ekf.launch.py
@@ -36,7 +36,7 @@ def launch_setup(context):
     # This function is executed at launch time
 
     use_sim_time = LaunchConfiguration("use_sim_time").perform(context)
-    profile = LaunchConfiguration("profile").perform(context)
+    profile = LaunchConfiguration("ekf_profile").perform(context)
 
     if profile not in ekf_profiles:
         raise ValueError(
@@ -106,7 +106,7 @@ def generate_launch_description():
     )
 
     profile_cmd = DeclareLaunchArgument(
-        "profile",
+        "ekf_profile",
         default_value=default_profile,
         description="Select the EKF profile to use (gps, lidar)",
     )

--- a/src/Nav/navigation/config/elevation_mapping/postprocessing_traversability.yaml
+++ b/src/Nav/navigation/config/elevation_mapping/postprocessing_traversability.yaml
@@ -4,15 +4,6 @@ elevation_mapping:
     output_topic: trasversability_map
 
     postprocessor_pipeline:
-
-        # General note: Using MedianFilter instead of inpaint because inpaint is broken
-        # Inpaint filter is broken, stacktrace below:
-        #0  0x0000fffff6bb7724 in cv::_OutputArray::create(cv::Size_<int>, int, int, bool, cv::_OutputArray::DepthMask) const () 
-        #           from /lib/aarch64-linux-gnu/libopencv_core.so.4.5d
-        #1  0x0000fffff7a4c890 in cv::inpaint(cv::_InputArray const&, cv::_InputArray const&, cv::_OutputArray const&, double, int) () from /lib/libopencv_photo.so.408
-        #2  0x0000fffff7aa1c94 in ?? () from /opt/ros/humble/lib/libgrid_map_cv.so
-        #3  0x0000aaaaaab78fac in elevation_mapping::PostprocessingPipelineFunctor::operator()(grid_map::GridMap&) ()
-
       filter1:
         name: buffer_normalizer
         type: gridMapFilters/BufferNormalizerFilter
@@ -23,32 +14,27 @@ elevation_mapping:
         name: delete_original_layers
         type: gridMapFilters/DeletionFilter
         params:
-          layers: [color, lowest_scan_point,sensor_x_at_lowest_scan, sensor_y_at_lowest_scan, sensor_z_at_lowest_scan] # List of layers.
+          layers: [color, lowest_scan_point,sensor_x_at_lowest_scan, sensor_y_at_lowest_scan, sensor_z_at_lowest_scan, variance, horizontal_variance_x, horizontal_variance_y, horizontal_variance_xy, time, dynamic_time] # List of layers.
 
-      # Fill holes in the elevation map using a median filter.
-      # filter2:
-      #   name: median
-      #   type: gridMapFilters/MedianFillFilter
+      ##### Option 1 - InpaintFilter then radial blur #####
+      # filter3:  # Fill holes in the map with inpainting.
+      #   name: inpaint
+      #   type: gridMapCv/InpaintFilter
       #   params:
       #     input_layer: elevation
-      #     output_layer: elevation_filled
-      #     fill_hole_radius: 0.05 # in m. 
-      #     filter_existing_values: false # Default is false. If enabled it also does a median computation for existing values. 
-      #     existing_value_radius: 0.2 # in m. Note that this option only has an effect if filter_existing_values is set true. 
-      #     fill_mask_layer: fill_mask # A layer that is used to compute which areas to fill. If not present in the input it is automatically computed. 
-      #     debug: false # If enabled, the additional debug_infill_mask_layer is published. 
-      #     debug_infill_mask_layer: infill_mask # Layer used to visualize the intermediate, sparse-outlier removed fill mask. Only published if debug is enabled
+      #     output_layer: elevation_inpainted
+      #     radius: 0.05
 
-      # # Reduce noise with a radial blurring filter.
-      # filter3:
+      # Reduce noise with a radial blurring filter.
+      # filter4:
       #   name: mean_in_radius
       #   type: gridMapFilters/MeanInRadiusFilter
       #   params:
-      #     input_layer: elevation_filled
+      #     input_layer: elevation_inpainted
       #     output_layer: elevation_smooth
       #     radius: 0.06
 
-      # Boxblur as an alternative to the inpaint and radial blurring filter above.
+      ##### Option 2 - Boxblur computing empty cells #####
       filter3:
         name: boxblur
         type: gridMapFilters/SlidingWindowMathExpressionFilter
@@ -71,16 +57,8 @@ elevation_mapping:
           radius: 0.35 # 1.5 times the map resolution is good
           normal_vector_positive_axis: z
 
-      # Add a color layer for visualization based on the surface normal.
-      filter5:
-        name: normal_color_map
-        type: gridMapFilters/NormalColorMapFilter
-        params:
-          input_layers_prefix: normal_vectors_
-          output_layer: normal_color
-
       # Compute slope from surface normal.
-      filter6:
+      filter5:
         name: slope
         type: gridMapFilters/MathExpressionFilter
         params:
@@ -88,27 +66,15 @@ elevation_mapping:
           expression: acos(normal_vectors_z)
 
       # Compute roughness as absolute difference from map to smoothened map.
-      filter7:
+      filter6:
         name: roughness
         type: gridMapFilters/MathExpressionFilter
         params:
           output_layer: roughness
           expression: abs(elevation - elevation_smooth)
 
-      # # Edge detection by computing the standard deviation from slope.
-      # filter8:
-      #   name: edge_detection
-      #   type: gridMapFilters/SlidingWindowMathExpressionFilter
-      #   params:
-      #     input_layer: slope
-      #     output_layer: edges
-      #     expression: sqrt(sumOfFinites(square(slope - meanOfFinites(slope))) ./ numberOfFinites(slope)) # Standard deviation
-      #     compute_empty_cells: false
-      #     edge_handling: crop # options: inside, crop, empty, mean
-      #     window_length: 0.2
-
       # Compute traversability as normalized weighted sum of slope and roughness.
-      filter8:
+      filter7:
         name: traversability
         type: gridMapFilters/MathExpressionFilter
         params:
@@ -116,7 +82,7 @@ elevation_mapping:
           expression: 0.13 * (slope / 0.6) + 0.24 * (roughness / 0.1) # roughness: 0.3
 
       # Set lower threshold on traversability.
-      filter9:
+      filter8:
         name: traversability_lower_threshold
         type: gridMapFilters/ThresholdFilter
         params:
@@ -126,7 +92,7 @@ elevation_mapping:
           set_to: 0.0
 
       # Set upper threshold on traversability.
-      filter10:
+      filter9:
         name: traversability_upper_threshold
         type: gridMapFilters/ThresholdFilter
         params:
@@ -136,7 +102,7 @@ elevation_mapping:
           set_to: 1.0 # Other uses: .nan, .inf
 
       # Inflate the traversability map to account for the robot's footprint.
-      filter11:
+      filter10:
         name: preserve_cost_inflation_filter
         type: cprtGridMapFilters/PreserveCostInflationFilter
         params:
@@ -145,3 +111,9 @@ elevation_mapping:
           core_inflation_radius: 0.8 # in m
           decay_inflation_radius: 0.8 # in m
           decay_rate: 1.2 # See script at /src/cprt_grid_map_filters/scripts/calculate_decay_rate.py to help calculate.
+      
+      filter11:
+        name: delete_unnecessary_layers
+        type: gridMapFilters/DeletionFilter
+        params:
+          layers: [roughness, slope, normal_vectors_x, normal_vectors_y, normal_vectors_z] # List of layers.

--- a/src/Nav/navigation/launch/nav2.launch.py
+++ b/src/Nav/navigation/launch/nav2.launch.py
@@ -111,7 +111,7 @@ def generate_launch_description():
 
     declare_use_composition_cmd = DeclareLaunchArgument(
         "use_composition",
-        default_value="False",
+        default_value="True",
         description="Use composed bringup if True",
     )
 
@@ -235,13 +235,13 @@ def generate_launch_description():
     # Node to create the container for composed nodes
     # This node needs to be launched when use_composition is true
     container = ComposableNodeContainer(
-        namespace="",
+        namespace=namespace,
         package="rclcpp_components",
         executable="component_container_isolated",
-        arguments=["--use_multi_threaded_executor"],
         name=container_name,
         output="screen",
         condition=IfCondition(use_composition),
+        parameters=[configured_params],
     )
 
     # Group of actions to load composable nodes when composition is enabled
@@ -253,60 +253,42 @@ def generate_launch_description():
                 package="nav2_controller",
                 plugin="nav2_controller::ControllerServer",
                 name="controller_server",
-                parameters=[
-                    configured_params,
-                    {"use_intra_process_comms": use_intra_process_comms},
-                ],
+                parameters=[configured_params],
                 remappings=remappings,
             ),
             ComposableNode(
                 package="nav2_smoother",
                 plugin="nav2_smoother::SmootherServer",
                 name="smoother_server",
-                parameters=[
-                    configured_params,
-                    {"use_intra_process_comms": use_intra_process_comms},
-                ],
+                parameters=[configured_params],
                 remappings=remappings,
             ),
             ComposableNode(
                 package="nav2_planner",
                 plugin="nav2_planner::PlannerServer",
                 name="planner_server",
-                parameters=[
-                    configured_params,
-                    {"use_intra_process_comms": use_intra_process_comms},
-                ],
+                parameters=[configured_params],
                 remappings=remappings,
             ),
             ComposableNode(
                 package="nav2_behaviors",
                 plugin="behavior_server::BehaviorServer",
                 name="behavior_server",
-                parameters=[
-                    configured_params,
-                    {"use_intra_process_comms": use_intra_process_comms},
-                ],
+                parameters=[configured_params],
                 remappings=remappings,
             ),
             ComposableNode(
                 package="nav2_bt_navigator",
                 plugin="nav2_bt_navigator::BtNavigator",
                 name="bt_navigator",
-                parameters=[
-                    configured_params,
-                    {"use_intra_process_comms": use_intra_process_comms},
-                ],
+                parameters=[configured_params],
                 remappings=remappings,
             ),
             ComposableNode(
                 package="nav2_waypoint_follower",
                 plugin="nav2_waypoint_follower::WaypointFollower",
                 name="waypoint_follower",
-                parameters=[
-                    configured_params,
-                    {"use_intra_process_comms": use_intra_process_comms},
-                ],
+                parameters=[configured_params],
                 remappings=remappings,
             ),
             ComposableNode(
@@ -326,10 +308,7 @@ def generate_launch_description():
                 package="nav2_velocity_smoother",
                 plugin="nav2_velocity_smoother::VelocitySmoother",
                 name="velocity_smoother",
-                parameters=[
-                    configured_params,
-                    {"use_intra_process_comms": use_intra_process_comms},
-                ],
+                parameters=[configured_params],
             ),
         ],
     )

--- a/src/Nav/navigation/launch/nav2.launch.py
+++ b/src/Nav/navigation/launch/nav2.launch.py
@@ -20,7 +20,7 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, GroupAction, SetEnvironmentVariable
 from launch.conditions import IfCondition
 from launch.substitutions import LaunchConfiguration, PythonExpression
-from launch_ros.actions import LoadComposableNodes
+from launch_ros.actions import LoadComposableNodes, ComposableNodeContainer
 from launch_ros.actions import Node
 from launch_ros.descriptions import ComposableNode
 from nav2_common.launch import RewrittenYaml
@@ -234,9 +234,11 @@ def generate_launch_description():
 
     # Node to create the container for composed nodes
     # This node needs to be launched when use_composition is true
-    container = Node(
+    container = ComposableNodeContainer(
+        namespace="",
         package="rclcpp_components",
-        executable="component_container",
+        executable="component_container_isolated",
+        arguments=["--use_multi_threaded_executor"],
         name=container_name,
         output="screen",
         condition=IfCondition(use_composition),

--- a/src/Nav/navigation/launch/slam.launch.py
+++ b/src/Nav/navigation/launch/slam.launch.py
@@ -12,6 +12,7 @@ from launch.conditions import IfCondition
 def generate_launch_description():
     # Get package directories
     pkg_navigation = get_package_share_directory("navigation")
+    pkg_localization = get_package_share_directory("localization")
 
     # Launch configurations
     use_sim_time = LaunchConfiguration("use_sim_time")
@@ -19,12 +20,14 @@ def generate_launch_description():
     launch_traversability = LaunchConfiguration("launch_traversability")
     launch_zed = LaunchConfiguration("launch_zed")
     launch_ouster = LaunchConfiguration("launch_ouster")
+    launch_localization = LaunchConfiguration("launch_localization")
 
     # Declare launch arguments
     declare_use_sim_time = DeclareLaunchArgument("use_sim_time", default_value="false")
     declare_traversability = DeclareLaunchArgument(
         "launch_traversability", default_value="True"
     )
+    declare_localization = DeclareLaunchArgument("launch_localization", default_value="True")
     declare_zed = DeclareLaunchArgument("launch_zed", default_value="True")
     declare_ouster = DeclareLaunchArgument("launch_ouster", default_value="False")
     declare_svo_path = DeclareLaunchArgument(
@@ -33,16 +36,14 @@ def generate_launch_description():
         description="Path to an input SVO file.",
     )
 
-    # Include nav2 (with composition and container name)
-    nav2_cmd = IncludeLaunchDescription(
+    localization_cmd = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
-            os.path.join(pkg_navigation, "launch", "nav2.launch.py")
+            os.path.join(pkg_localization, "launch", "localization.launch.py")
         ),
-        launch_arguments={
-            "use_sim_time": use_sim_time,
-            "use_composition": "False",
-        }.items(),
+        condition=IfCondition(launch_localization),
+        launch_arguments={"use_sim_time": use_sim_time}.items(),
     )
+
     zed_cmd = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
             os.path.join(pkg_navigation, "launch", "zed.launch.py")
@@ -86,9 +87,10 @@ def generate_launch_description():
             declare_traversability,
             declare_zed,
             declare_ouster,
-            nav2_cmd,
-            traversability_cmd,
+            declare_localization,
             zed_cmd,
+            traversability_cmd,
             ouster_cmd,
+            localization_cmd,
         ]
     )

--- a/src/Nav/navigation/launch/slam.launch.py
+++ b/src/Nav/navigation/launch/slam.launch.py
@@ -27,7 +27,9 @@ def generate_launch_description():
     declare_traversability = DeclareLaunchArgument(
         "launch_traversability", default_value="True"
     )
-    declare_localization = DeclareLaunchArgument("launch_localization", default_value="True")
+    declare_localization = DeclareLaunchArgument(
+        "launch_localization", default_value="True"
+    )
     declare_zed = DeclareLaunchArgument("launch_zed", default_value="True")
     declare_ouster = DeclareLaunchArgument("launch_ouster", default_value="False")
     declare_svo_path = DeclareLaunchArgument(


### PR DESCRIPTION
## Changed how we launch autonomy:
slam.launch.py:
- zed camera
- all localization
- elevation/traversability mapping
- Ouster (default no)

nav2.launch.py
- all nav2 components

When launching nav2 as a composible nodes there is a race condition with the zed camera. Always launch slam.launch.py before nav2.launch.py

## Removed layers from output of traversability map
- Makes the output smaller so the dds doesn't work as hard

## Tested with infill filter
- Seems to work
- Lower latency than the box blur method
- Need to verify that the output is at least as good