### PR TITLE
Feature/srt component wip

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,4 +10,4 @@ find ./src -path ./src/third-party -prune -o \
 
 rosdep install --from-paths src -i -r -y
 
-colcon build --symlink-install --continue-on-error --cmake-args=-DCMAKE_BUILD_TYPE=Release --parallel-workers $(nproc)
+colcon build --symlink-install --continue-on-error --cmake-args=-DCMAKE_BUILD_TYPE=Release --parallel-workers 1

--- a/src/Cameras/video_streaming/CMakeLists.txt
+++ b/src/Cameras/video_streaming/CMakeLists.txt
@@ -8,10 +8,13 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # ---- Dependencies
 find_package(ament_cmake REQUIRED)
+find_package(rosidl_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(rosidl_default_runtime REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
+find_package(std_msgs REQUIRED)
 find_package(std_srvs REQUIRED)
-find_package(interfaces REQUIRED)
 find_package(PkgConfig REQUIRED)
 
 pkg_check_modules(GSTREAMER REQUIRED IMPORTED_TARGET gstreamer-1.0)
@@ -20,47 +23,64 @@ pkg_check_modules(GST_VIDEO REQUIRED IMPORTED_TARGET gstreamer-video-1.0)
 
 add_subdirectory(gst-plugins)
 
-# ---- Targets
-add_library(${PROJECT_NAME} SHARED
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "srv/SetStreamingParams.srv"
+  "msg/Srtstat.msg"
+)
+
+
+add_library(video_streaming_nodes SHARED
   src/base_video_node.cpp
   src/input_node.cpp
   src/detect_node.cpp
   src/webrtc_node.cpp
+  src/srt_node.cpp
 )
 
-include_directories(
-  include/${PROJECT_NAME}
+
+target_include_directories(video_streaming_nodes PUBLIC
+  "include" 
   ${GSTREAMER_INCLUDE_DIRS}
   ${GST_APP_INCLUDE_DIRS}
   ${GST_VIDEO_INCLUDE_DIRS}
 )
 
-target_link_directories(${PROJECT_NAME} PRIVATE ${GST_LIBRARY_DIRS})
-target_link_libraries(${PROJECT_NAME} 
+target_link_libraries(video_streaming_nodes
   PkgConfig::GSTREAMER
   PkgConfig::GST_APP
   PkgConfig::GST_VIDEO
 )
-ament_target_dependencies(${PROJECT_NAME}
+
+ament_target_dependencies(video_streaming_nodes
   rclcpp
   rclcpp_components
-  interfaces
   std_srvs
+  std_msgs
+  rosidl_default_runtime
 )
+rosidl_target_dependencies(video_streaming_nodes
+
+  ${${PROJECT_NAME}_INSTALL_DIR}/share/${PROJECT_NAME}/cmake/rosidl_generator_c
+
+  ${${PROJECT_NAME}_INSTALL_DIR}/share/${PROJECT_NAME}/cmake/rosidl_generator_cpp
+
+) 
+
 
 # If pkg-config provided extra compile flags (e.g., -D, -pthread)
-target_compile_options(${PROJECT_NAME} PRIVATE ${GST_CFLAGS_OTHER})
+target_compile_options(video_streaming_nodes PRIVATE ${GST_CFLAGS_OTHER})
 
-# Register both composable nodes
-rclcpp_components_register_nodes(${PROJECT_NAME}
+rclcpp_components_register_nodes(video_streaming_nodes 
   "InputNode"
   "DetectNode"
   "WebRtcNode"
+  "SrtNode"
 )
 
-# ---- Install
+
 install(
-  TARGETS ${PROJECT_NAME}
+  TARGETS video_streaming_nodes 
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
@@ -69,22 +89,25 @@ install(
   DIRECTORY include/
   DESTINATION include/
 )
-
 install(DIRECTORY launch
   DESTINATION share/${PROJECT_NAME}
 )
 install(DIRECTORY config
   DESTINATION share/${PROJECT_NAME}
 )
-
-# Install environment hooks so they are sourced by setup.bash
 ament_environment_hooks(
   hooks/gst_env_hook.sh
 )
 
-# ---- Export
-ament_export_include_directories(include/${PROJECT_NAME})
-ament_export_dependencies(rclcpp rclcpp_components)
-ament_export_libraries(${PROJECT_NAME})
 
+ament_export_include_directories(include)
+ament_export_dependencies(
+  rclcpp
+  rclcpp_components
+  std_msgs
+  std_srvs
+  rosidl_default_runtime
+)
+ament_export_libraries(video_streaming_nodes) 
 ament_package()
+

--- a/src/Cameras/video_streaming/include/video_streaming/srt_node.hpp
+++ b/src/Cameras/video_streaming/include/video_streaming/srt_node.hpp
@@ -1,0 +1,53 @@
+#pragma once
+#include "base_video_node.hpp"
+#include <gst/gst.h>
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/int32.hpp"  //bitrate
+#include "std_msgs/msg/empty.hpp"  //I-frame
+#include "video_streaming/srv/set_streaming_params.hpp"
+#include "video_streaming/msg/srtstat.hpp"
+
+
+namespace video_streaming
+
+{
+class SrtNode : public BaseVideoNode {
+public:
+  explicit SrtNode(
+            const rclcpp::NodeOptions &options = rclcpp::NodeOptions());            
+  ~SrtNode() override = default;
+
+protected:
+  // (interpipesrc -> nvvidconv -> nvv4l2av1enc -> srtsink)
+  bool create_pipeline() override;
+
+  GstElement * av1_encoder_ = nullptr;
+  GstElement * srt_sink_ = nullptr;
+
+
+  //bitrate
+  rclcpp::Subscription<std_msgs::msg::Int32>::SharedPtr bitrate_sub_;
+
+  // I-frame
+  rclcpp::Subscription<std_msgs::msg::Empty>::SharedPtr iframe_sub_;
+
+  rclcpp::Publisher<video_streaming::msg::Srtstat>::SharedPtr stats_pub_;
+
+  /**  (latency, I-frame interval, framerate) */
+  rclcpp::Service<video_streaming::srv::SetStreamingParams>::SharedPtr params_srv_; 
+
+private:
+
+  void on_bitrate_received(const std_msgs::msg::Int32::SharedPtr msg);
+
+  void on_iframe_trigger(const std_msgs::msg::Empty::SharedPtr msg);
+
+  void on_set_params(
+    const std::shared_ptr<video_streaming::srv::SetStreamingParams::Request> request,  
+    std::shared_ptr<video_streaming::srv::SetStreamingParams::Response> response);
+
+
+  static void on_srt_stats(GstElement * element, GstStructure * stats, gpointer user_data);
+};
+
+} 

--- a/src/Cameras/video_streaming/msg/Srtstat.msg
+++ b/src/Cameras/video_streaming/msg/Srtstat.msg
@@ -1,0 +1,5 @@
+float64 rtt            # Round-trip time (in seconds)
+float64 bandwidth      # Estimated bandwidth (in bits/sec)
+int64 packets_sent
+int64 packets_lost
+int64 packets_retransmitted

--- a/src/Cameras/video_streaming/package.xml
+++ b/src/Cameras/video_streaming/package.xml
@@ -8,11 +8,18 @@
   <license>TODO: License declaration</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend>rosidl_default_generators</build_depend>
+
   <depend>rclcpp</depend>
-  <depend>interfaces</depend>
   <depend>std_srvs</depend>
+  <depend>std_msgs</depend> 
+  
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>
+    
   </export>
 </package>

--- a/src/Cameras/video_streaming/src/srt_node.cpp
+++ b/src/Cameras/video_streaming/src/srt_node.cpp
@@ -1,0 +1,134 @@
+#include "srt_node.hpp"
+#include <rclcpp_components/register_node_macro.hpp>
+#include <glib.h>
+
+namespace video_streaming 
+{
+
+SrtNode::SrtNode(const rclcpp::NodeOptions &options)
+  : BaseVideoNode("srt_node", options) 
+{
+    RCLCPP_INFO(this->get_logger(), "Initializing SrtNode...");
+
+    // Start up
+    this->declare_parameter<std::string>("srt_uri", "srt://127.0.0.1:12345");
+    
+    bitrate_sub_ = this->create_subscription<std_msgs::msg::Int32>(
+        "~/set_bitrate", 10,
+        std::bind(&SrtNode::on_bitrate_received, this, std::placeholders::_1));
+
+    iframe_sub_ = this->create_subscription<std_msgs::msg::Empty>(
+        "~/trigger_iframe", 10,
+        std::bind(&SrtNode::on_iframe_trigger, this, std::placeholders::_1));
+
+    stats_pub_ = this->create_publisher<video_streaming::msg::Srtstat>("~/srt_stats", 10);
+
+    params_srv_ = this->create_service<video_streaming::srv::SetStreamingParams>(
+        "~/set_params",
+        std::bind(&SrtNode::on_set_params, this, std::placeholders::_1, std::placeholders::_2));
+
+    if (!start_pipeline()) {
+        RCLCPP_FATAL(get_logger(), "SrtNode: failed to start pipeline.");
+        throw std::runtime_error("SrtNode: pipeline start failed");
+    }
+    RCLCPP_INFO(get_logger(), "SrtNode constructed and pipeline started.");
+}
+
+
+bool SrtNode::create_pipeline()
+{
+    std::string srt_uri = this->get_parameter("srt_uri").as_string();
+
+
+    gchar *desc = g_strdup_printf(
+        "interpipesrc listen-to=detect ! "
+        "nvvidconv ! "
+        "nvv4l2av1enc name=av1_enc ! "
+        "rtpav1pay ! queue ! "
+        "srtsink name=srt_sink uri=%s mode=1",
+        srt_uri.c_str()
+    );
+    RCLCPP_INFO(this->get_logger(), "Using pipeline description: %s", desc);
+
+    // same as webrtc_node.cpp
+    GError *err = nullptr;
+    GstElement *p = gst_parse_launch(desc, &err);
+    g_free(desc); 
+
+    if (err || !p) {
+        RCLCPP_ERROR(get_logger(), "gst_parse_launch failed: %s",
+                     err ? err->message : "unknown");
+        if (err) g_error_free(err);
+        return false;
+    }
+    if (!GST_IS_PIPELINE(p)) {
+        RCLCPP_ERROR(get_logger(), "Parsed element is not a pipeline.");
+        gst_object_unref(p);
+        return false;
+    }
+    pipeline_ = p; 
+
+    av1_encoder_ = this->get_element("av1_enc");
+    srt_sink_ = this->get_element("srt_sink");
+
+    if (!av1_encoder_ || !srt_sink_) {
+        RCLCPP_ERROR(get_logger(), "Failed to get elements by name");
+        return false;
+    }
+
+ 
+    g_signal_connect(srt_sink_, "get-stats", G_CALLBACK(SrtNode::on_srt_stats), this);
+
+    RCLCPP_INFO(this->get_logger(), "Pipeline parsed and elements retrieved successfully.");
+    return true;
+}
+
+ 
+
+
+void SrtNode::on_bitrate_received(const std_msgs::msg::Int32::SharedPtr msg)
+{
+    if (av1_encoder_) {
+        g_object_set(av1_encoder_, "bitrate", msg->data, NULL);
+        RCLCPP_INFO(this->get_logger(), "Bitrate set to %d", msg->data);
+    }
+}
+
+void SrtNode::on_iframe_trigger(const std_msgs::msg::Empty::SharedPtr msg)
+{
+    (void)msg;
+    if (av1_encoder_) {
+        // nvv4l2av1enc  'force-key-unit' )
+        g_signal_emit_by_name(av1_encoder_, "force-key-unit", NULL);
+        RCLCPP_INFO(this->get_logger(), "I-Frame triggered");
+    }
+}
+
+void SrtNode::on_set_params(
+    const std::shared_ptr<video_streaming::srv::SetStreamingParams::Request> request,
+    std::shared_ptr<video_streaming::srv::SetStreamingParams::Response> response)
+{
+    if (av1_encoder_ && srt_sink_) {
+        g_object_set(av1_encoder_, "iframeinterval", request->iframe_interval, NULL);
+        g_object_set(srt_sink_, "latency", request->latency, NULL);
+        
+        RCLCPP_INFO(this->get_logger(), "Parameters updated via service");
+        response->success = true;
+    } else {
+        response->success = false;
+        response->message = "Pipeline elements not available";
+    }
+}
+
+
+void SrtNode::on_srt_stats(GstElement * element, GstStructure * stats, gpointer user_data)
+{
+    SrtNode* node = static_cast<SrtNode*>(user_data);
+    auto stats_msg = video_streaming::msg::Srtstat();
+    
+    node->stats_pub_->publish(stats_msg);
+}
+
+} 
+
+RCLCPP_COMPONENTS_REGISTER_NODE(video_streaming::SrtNode)

--- a/src/Cameras/video_streaming/srv/SetStreamingParams.srv
+++ b/src/Cameras/video_streaming/srv/SetStreamingParams.srv
@@ -1,0 +1,8 @@
+# request
+int32 latency
+int32 iframe_interval
+int32 framerate
+---
+#respond 
+bool success
+string message


### PR DESCRIPTION

This PR adds a Work-in-Progress implementation of the SRT video streaming component.  

Progress so far: 
- Added initial `srt_node.cpp` and `srt_node.hpp` structure  
- Implemented custom message (`Srtstat.msg`)  
- Added related service definition  
- Updated `CMakeLists.txt` to include the new node, msg, and srv  
- Updated `package.xml` with the required dependencies  
- Basic component registration in place

Feedback requested:
- Whether the current component structure is aligned with the pipeline design  
- Whether the message and service setup is appropriate  
- Guidance on how to test this SRT:
  - the composable node architecture  
  - the video streaming pipeline  
  - any expected integration workflow


This branch also includes a small earlier build-related change (reducing parallel workers),I can remove later. 

