### PR TITLE
Add open loop drive option to talon drive controller

### DIFF
--- a/src/Teleop-Control/drive_cpp/config/talon_drive_unique.yaml
+++ b/src/Teleop-Control/drive_cpp/config/talon_drive_unique.yaml
@@ -24,3 +24,5 @@ talon_drive_controller:
     wheel_rad: 0.10
     angular_slip_ratio: 0.6
     low_latency_mode: true
+    is_open_loop: true
+    open_loop_scalar: 0.5  # Converts m/s of commanded velocity to a percent output

--- a/src/Teleop-Control/drive_cpp/include/drive_cpp/WheelControl.hpp
+++ b/src/Teleop-Control/drive_cpp/include/drive_cpp/WheelControl.hpp
@@ -35,10 +35,12 @@ public:
    * @brief Construct a new WheelControl object.
    * @param wheel_name The name of the wheel (e.g., "frontLeft", "backRight").
    * @param node A pointer to the ROS node for creating publishers.
+   * @param is_open_loop Whether to use open loop (PERCENT_OUTPUT) or closed loop (VELOCITY) control.
+   * @param open_loop_scalar Scalar multiplier for velocity commands when in open loop mode.
    * @throws std::invalid_argument if the wheel name doesn't include "Left" or
    * "Right".
    */
-  WheelControl(std::string wheel_name, rclcpp::Node *node);
+  WheelControl(std::string wheel_name, rclcpp::Node *node, bool is_open_loop, double open_loop_scalar);
 
   /**
    * @brief Set the velocity of the wheel.
@@ -102,6 +104,16 @@ private:
    * @brief Publisher for sending motor control messages.
    */
   rclcpp::Publisher<MotorControl>::SharedPtr pub_;
+
+  /**
+   * @brief Whether the wheel is operating in open loop mode (true) or closed loop mode (false).
+   */
+  bool is_open_loop_;
+
+  /**
+   * @brief Scalar multiplier applied to velocity commands when in open loop mode.
+   */
+  double open_loop_scalar_;
 };
 
 #endif // WHEEL_CONTROL_HPP

--- a/src/Teleop-Control/drive_cpp/include/drive_cpp/WheelControl.hpp
+++ b/src/Teleop-Control/drive_cpp/include/drive_cpp/WheelControl.hpp
@@ -35,12 +35,15 @@ public:
    * @brief Construct a new WheelControl object.
    * @param wheel_name The name of the wheel (e.g., "frontLeft", "backRight").
    * @param node A pointer to the ROS node for creating publishers.
-   * @param is_open_loop Whether to use open loop (PERCENT_OUTPUT) or closed loop (VELOCITY) control.
-   * @param open_loop_scalar Scalar multiplier for velocity commands when in open loop mode.
+   * @param is_open_loop Whether to use open loop (PERCENT_OUTPUT) or closed
+   * loop (VELOCITY) control.
+   * @param open_loop_scalar Scalar multiplier for velocity commands when in
+   * open loop mode.
    * @throws std::invalid_argument if the wheel name doesn't include "Left" or
    * "Right".
    */
-  WheelControl(std::string wheel_name, rclcpp::Node *node, bool is_open_loop, double open_loop_scalar);
+  WheelControl(std::string wheel_name, rclcpp::Node *node, bool is_open_loop,
+               double open_loop_scalar);
 
   /**
    * @brief Set the velocity of the wheel.
@@ -106,12 +109,14 @@ private:
   rclcpp::Publisher<MotorControl>::SharedPtr pub_;
 
   /**
-   * @brief Whether the wheel is operating in open loop mode (true) or closed loop mode (false).
+   * @brief Whether the wheel is operating in open loop mode (true) or closed
+   * loop mode (false).
    */
   bool is_open_loop_;
 
   /**
-   * @brief Scalar multiplier applied to velocity commands when in open loop mode.
+   * @brief Scalar multiplier applied to velocity commands when in open loop
+   * mode.
    */
   double open_loop_scalar_;
 };

--- a/src/Teleop-Control/drive_cpp/src/TalonDriveController.cpp
+++ b/src/Teleop-Control/drive_cpp/src/TalonDriveController.cpp
@@ -50,7 +50,8 @@ TalonDriveController::TalonDriveController(const rclcpp::NodeOptions &options)
       this->get_parameter("wheels").as_string_array();
 
   for (const auto &wheel_name : wheel_names) {
-    wheels_.emplace_back(WheelControl(wheel_name, this, is_open_loop, open_loop_scalar));
+    wheels_.emplace_back(
+        WheelControl(wheel_name, this, is_open_loop, open_loop_scalar));
     if (pubOdom_) {
       statusSubs_.emplace_back(this->create_subscription<MotorStatus>(
           wheel_name + "/status", 10,

--- a/src/Teleop-Control/drive_cpp/src/TalonDriveController.cpp
+++ b/src/Teleop-Control/drive_cpp/src/TalonDriveController.cpp
@@ -38,6 +38,11 @@ TalonDriveController::TalonDriveController(const rclcpp::NodeOptions &options)
   this->declare_parameter("low_latency_mode", true);
   low_latency_mode_ = this->get_parameter("low_latency_mode").as_bool();
 
+  this->declare_parameter("is_open_loop", true);
+  bool is_open_loop = this->get_parameter("is_open_loop").as_bool();
+  this->declare_parameter("open_loop_scalar", 0.5);
+  double open_loop_scalar = this->get_parameter("open_loop_scalar").as_double();
+
   this->declare_parameter("wheels",
                           std::vector<std::string>{"frontRight", "frontLeft",
                                                    "backRight", "backLeft"});
@@ -45,7 +50,7 @@ TalonDriveController::TalonDriveController(const rclcpp::NodeOptions &options)
       this->get_parameter("wheels").as_string_array();
 
   for (const auto &wheel_name : wheel_names) {
-    wheels_.emplace_back(WheelControl(wheel_name, this));
+    wheels_.emplace_back(WheelControl(wheel_name, this, is_open_loop, open_loop_scalar));
     if (pubOdom_) {
       statusSubs_.emplace_back(this->create_subscription<MotorStatus>(
           wheel_name + "/status", 10,

--- a/src/Teleop-Control/drive_cpp/src/WheelControl.cpp
+++ b/src/Teleop-Control/drive_cpp/src/WheelControl.cpp
@@ -2,8 +2,8 @@
 
 #include <iostream>
 
-WheelControl::WheelControl(std::string wheel_name, rclcpp::Node *node)
-    : node_(node), name_(wheel_name) {
+WheelControl::WheelControl(std::string wheel_name, rclcpp::Node *node, bool is_open_loop, double open_loop_scalar)
+    : node_(node), name_(wheel_name), is_open_loop_(is_open_loop), open_loop_scalar_(open_loop_scalar) {
   if (wheel_name.find("Left") != std::string::npos ||
       wheel_name.find("left") != std::string::npos) {
     side_ = WheelSide::LEFT;
@@ -17,10 +17,25 @@ WheelControl::WheelControl(std::string wheel_name, rclcpp::Node *node)
         "Wheel name must contain either 'Left' or 'Right'");
   }
   pub_ = node->create_publisher<MotorControl>(wheel_name + "/set", 10);
-  control_.mode = MotorControl::VELOCITY;
+  
+  if (is_open_loop_) {
+    control_.mode = MotorControl::PERCENT_OUTPUT;
+    RCLCPP_INFO(node->get_logger(), "Wheel %s configured for open loop control with scalar %.3f", 
+                wheel_name.c_str(), open_loop_scalar_);
+  } else {
+    control_.mode = MotorControl::VELOCITY;
+    RCLCPP_INFO(node->get_logger(), "Wheel %s configured for closed loop velocity control", 
+                wheel_name.c_str());
+  }
 }
 
-void WheelControl::setVelocity(double value) { control_.value = value; }
+void WheelControl::setVelocity(double value) { 
+  if (is_open_loop_) {
+    control_.value = value * open_loop_scalar_;
+  } else {
+    control_.value = value;
+  }
+}
 
 void WheelControl::send() const { pub_->publish(control_); }
 

--- a/src/Teleop-Control/drive_cpp/src/WheelControl.cpp
+++ b/src/Teleop-Control/drive_cpp/src/WheelControl.cpp
@@ -2,8 +2,10 @@
 
 #include <iostream>
 
-WheelControl::WheelControl(std::string wheel_name, rclcpp::Node *node, bool is_open_loop, double open_loop_scalar)
-    : node_(node), name_(wheel_name), is_open_loop_(is_open_loop), open_loop_scalar_(open_loop_scalar) {
+WheelControl::WheelControl(std::string wheel_name, rclcpp::Node *node,
+                           bool is_open_loop, double open_loop_scalar)
+    : node_(node), name_(wheel_name), is_open_loop_(is_open_loop),
+      open_loop_scalar_(open_loop_scalar) {
   if (wheel_name.find("Left") != std::string::npos ||
       wheel_name.find("left") != std::string::npos) {
     side_ = WheelSide::LEFT;
@@ -17,19 +19,21 @@ WheelControl::WheelControl(std::string wheel_name, rclcpp::Node *node, bool is_o
         "Wheel name must contain either 'Left' or 'Right'");
   }
   pub_ = node->create_publisher<MotorControl>(wheel_name + "/set", 10);
-  
+
   if (is_open_loop_) {
     control_.mode = MotorControl::PERCENT_OUTPUT;
-    RCLCPP_INFO(node->get_logger(), "Wheel %s configured for open loop control with scalar %.3f", 
+    RCLCPP_INFO(node->get_logger(),
+                "Wheel %s configured for open loop control with scalar %.3f",
                 wheel_name.c_str(), open_loop_scalar_);
   } else {
     control_.mode = MotorControl::VELOCITY;
-    RCLCPP_INFO(node->get_logger(), "Wheel %s configured for closed loop velocity control", 
+    RCLCPP_INFO(node->get_logger(),
+                "Wheel %s configured for closed loop velocity control",
                 wheel_name.c_str());
   }
 }
 
-void WheelControl::setVelocity(double value) { 
+void WheelControl::setVelocity(double value) {
   if (is_open_loop_) {
     control_.value = value * open_loop_scalar_;
   } else {


### PR DESCRIPTION
Spike has a broken encoder which makes teleop weird and autonomy testing likely impossible. I've tried to add a open loop option to the talon drive controller so we can still operate spike in the meantime. 

Is this implementation good? 

Tested on rover. Looks good.

# Copilot PR summary
This pull request introduces support for open loop motor control in the Talon drive system, allowing wheels to operate either in open loop (percent output) or closed loop (velocity) mode. The configuration is now parameterized, enabling flexible control mode selection and tuning via the YAML config file and ROS parameters. The most important changes are grouped below:

**Open Loop Control Feature:**

* Added `is_open_loop` and `open_loop_scalar` parameters to the YAML config (`talon_drive_unique.yaml`) to enable open loop mode and set the velocity-to-percent-output conversion scalar.
* Updated the `WheelControl` class constructor to accept `is_open_loop` and `open_loop_scalar`, and added corresponding member variables. [[1]](diffhunk://#diff-b89f983e3e541b5f58b275099d81cdb385d7661b4d766497edda84ea050c0530R38-R43) [[2]](diffhunk://#diff-b89f983e3e541b5f58b275099d81cdb385d7661b4d766497edda84ea050c0530R107-R116)
* Modified the wheel initialization logic in `TalonDriveController.cpp` to read the new parameters and pass them to each `WheelControl` instance.

**Control Mode Logic:**

* Enhanced the `WheelControl` constructor to configure control mode (open loop or closed loop) based on parameters, and log the selected mode for each wheel. [[1]](diffhunk://#diff-ce197a8963d48dc6f49339747c71ff15e4dda92cd06eaf1715d84888cec5e03aL5-R6) [[2]](diffhunk://#diff-ce197a8963d48dc6f49339747c71ff15e4dda92cd06eaf1715d84888cec5e03aR20-R38)
* Updated the `setVelocity` method in `WheelControl` to apply the scalar conversion when in open loop mode, ensuring correct command output.