### PR TITLE
Offset issues

### DIFF
--- a/src/Arm/arm_srdf/config/arm_urdf.ros2_control.xacro
+++ b/src/Arm/arm_srdf/config/arm_urdf.ros2_control.xacro
@@ -31,7 +31,7 @@
         <param name="kF">100</param>
         <param name="sensor_type">absolute</param> <!-- or "quadrature" -->
         <param name="sensor_ticks">4096</param>
-        <param name="sensor_offset">5.125</param>
+        <param name="sensor_offset">3.0</param>
         <param name="crossover">true</param> <!-- or "continuous" -->
         <param name="invert">false</param>
         <param name="invert_sensor">true</param>
@@ -47,7 +47,7 @@
         <param name="kF">60.0</param>
         <param name="sensor_type">absolute</param> <!-- or "quadrature" -->
         <param name="sensor_ticks">4096</param>
-        <param name="sensor_offset">3.35</param>
+        <param name="sensor_offset">-3.0</param>
         <param name="crossover">true</param> <!-- or "continuous" -->
         <param name="invert">true</param>
         <param name="invert_sensor">false</param>
@@ -79,7 +79,7 @@
         <param name="kF">7.8</param>
         <param name="sensor_type">absolute</param> <!-- or "quadrature" -->
         <param name="sensor_ticks">4096</param>
-        <param name="sensor_offset">6.05</param>
+        <param name="sensor_offset">0.4</param>
         <param name="crossover">true</param> <!-- or "continuous" -->
         <param name="invert">true</param>
         <param name="invert_sensor">true</param>

--- a/src/Arm/arm_urdf/urdf/arm_urdf.urdf
+++ b/src/Arm/arm_urdf/urdf/arm_urdf.urdf
@@ -156,7 +156,7 @@
       link="Link_3" />
     <axis
       xyz="0 -1 0" />
-    <limit effort="100.0" velocity="0.10" lower="-0.694" upper="0.211"/>
+    <limit effort="100.0" velocity="0.10" lower="-0.55" upper="0.31"/>
   </joint>
   <link
     name="Link_4">
@@ -210,7 +210,7 @@
       link="Link_4" />
     <axis
       xyz="0 -1 0" />
-    <limit effort="100.0" velocity="0.1" lower="1.538" upper="2.402"/>
+    <limit effort="100.0" velocity="0.1" lower="-1.178" upper="0.957"/>
   </joint>
   <link
     name="Link_5">
@@ -318,7 +318,7 @@
       link="Link_6" />
     <axis
       xyz="0 -1 0" />
-    <limit effort="100.0" velocity="1.0" lower="-1.371" upper="0.828"/>
+    <limit effort="100.0" velocity="1.0" lower="-1.7794" upper="0.655"/>
   </joint>
   <link
     name="Link_7">

--- a/src/HW-Devices/hardware/include/TalonSRXWrapper.hpp
+++ b/src/HW-Devices/hardware/include/TalonSRXWrapper.hpp
@@ -45,11 +45,7 @@ public:
 
 private:
   const hardware_interface::ComponentInfo info_;
-  enum class SensorType {
-    PWM,
-    RELATIVE,
-    ANALOG
-  }; 
+  enum class SensorType { PWM, RELATIVE, ANALOG };
 
   // Parameters
   int id_;

--- a/src/HW-Devices/hardware/include/TalonSRXWrapper.hpp
+++ b/src/HW-Devices/hardware/include/TalonSRXWrapper.hpp
@@ -45,6 +45,11 @@ public:
 
 private:
   const hardware_interface::ComponentInfo info_;
+  enum class SensorType {
+    PWM,
+    RELATIVE,
+    ANALOG
+  }; 
 
   // Parameters
   int id_;
@@ -53,7 +58,7 @@ private:
   double kD_;
   double kF_;
   ctre::phoenix::motorcontrol::ControlMode control_type_;
-  ctre::phoenix::motorcontrol::TalonSRXFeedbackDevice sensor_type_;
+  SensorType sensor_type_;
   int sensor_ticks_;
   double sensor_offset_;
   bool crossover_mode_;

--- a/src/HW-Devices/hardware/src/TalonSRXWrapper.cpp
+++ b/src/HW-Devices/hardware/src/TalonSRXWrapper.cpp
@@ -214,11 +214,11 @@ void TalonSRXWrapper::configure() {
     break;
   }
   int real_ticks = 0;
+  int offset_ticks =
+      static_cast<int>(sensor_offset_ * sensor_ticks_ / (2.0 * M_PI));
   if (sensor_type_ == SensorType::PWM) {
     auto &sc = talon_controller_->GetSensorCollection();
     int current_ticks = sc.GetPulseWidthPosition() & 0xFFF;
-    int offset_ticks =
-        static_cast<int>(sensor_offset_ * sensor_ticks_ / (2.0 * M_PI));
     real_ticks = current_ticks - offset_ticks;
   } else if (sensor_type_ == SensorType::RELATIVE) {
     real_ticks = offset_ticks;
@@ -230,8 +230,9 @@ void TalonSRXWrapper::configure() {
 
   talon_controller_->SetNeutralMode(NeutralMode::Brake);
   talon_controller_->ConfigSelectedFeedbackCoefficient(1.0);
-  // Talon's virtualize a QuadEncoder from the PWM signal if no quad encoder is
-  // present. The absolute part is set at the beginning from the
+
+  // The Talons virtualize a QuadEncoder from the PWM signal if no quad encoder
+  // is present. The absolute part is set at the beginning from the
   // SetSelectedSensorPosition
   talon_controller_->ConfigSelectedFeedbackSensor(FeedbackDevice::QuadEncoder,
                                                   0, 0);

--- a/src/HW-Devices/hardware/src/TalonSRXWrapper.cpp
+++ b/src/HW-Devices/hardware/src/TalonSRXWrapper.cpp
@@ -14,7 +14,7 @@ TalonSRXWrapper::TalonSRXWrapper(const hardware_interface::ComponentInfo &joint,
   talon_controller_ = nullptr;
   debug_pub_ = nullptr;
   debug_timer_ = nullptr;
-  sensor_type_ = motors::TalonSRXFeedbackDevice::CTRE_MagEncoder_Relative;
+  sensor_type_ = SensorType::RELATIVE;
   sensor_ticks_ = 4096;
   sensor_offset_ = 0.0;
   crossover_mode_ = false;
@@ -99,11 +99,11 @@ TalonSRXWrapper::TalonSRXWrapper(const hardware_interface::ComponentInfo &joint,
                  sensor_type_str.begin(),
                  [](unsigned char c) { return std::tolower(c); });
   if (sensor_type_str == "quadrature") {
-    sensor_type_ = motors::TalonSRXFeedbackDevice::CTRE_MagEncoder_Relative;
+    sensor_type_ = SensorType::RELATIVE;
   } else if (sensor_type_str == "absolute") {
-    sensor_type_ = motors::TalonSRXFeedbackDevice::CTRE_MagEncoder_Absolute;
+    sensor_type_ = SensorType::PWM;
   } else if (sensor_type_str == "analog") {
-    sensor_type_ = motors::TalonSRXFeedbackDevice::Analog;
+    sensor_type_ = SensorType::ANALOG;
   }
 }
 
@@ -126,7 +126,7 @@ void TalonSRXWrapper::pub_status() const {
 void TalonSRXWrapper::write() {
   double output = 0.0;
   if (control_type_ == motors::ControlMode::Position) {
-    output = (command_ - sensor_offset_) * sensor_ticks_ / (2.0 * M_PI);
+    output = command_ * sensor_ticks_ / (2.0 * M_PI);
   } else if (control_type_ == motors::ControlMode::Velocity) {
     output = command_ * sensor_ticks_ / (2.0 * M_PI) /
              10.0; // Convert rad/s to ticks per 100ms
@@ -136,7 +136,7 @@ void TalonSRXWrapper::write() {
 
 void TalonSRXWrapper::read() {
   double raw_ticks = talon_controller_->GetSelectedSensorPosition();
-  double position = ((raw_ticks / sensor_ticks_) * 2.0 * M_PI) + sensor_offset_;
+  double position = ((raw_ticks / sensor_ticks_) * 2.0 * M_PI);
 
   // Crossover mode: wrap between -pi and pi
   if (crossover_mode_) {
@@ -192,7 +192,6 @@ void TalonSRXWrapper::configure() {
     slot.kP = kP_;
     slot.kI = kI_;
     slot.kD = kD_;
-    // TODO: Add support for F, and other parameters if needed
     slot.kF = kF_;
 
     TalonSRXConfiguration config;
@@ -214,14 +213,33 @@ void TalonSRXWrapper::configure() {
     }
     break;
   }
+  int real_ticks = 0;
+  if (sensor_type_ == SensorType::PWM) {
+    auto &sc = talon_controller_->GetSensorCollection();
+    int current_ticks = sc.GetPulseWidthPosition() & 0xFFF;
+    int offset_ticks =
+        static_cast<int>(sensor_offset_ * sensor_ticks_ / (2.0 * M_PI));
+    real_ticks = current_ticks - offset_ticks;
+  } else if (sensor_type_ == SensorType::RELATIVE) {
+    real_ticks = offset_ticks;
+  } else if (sensor_type_ == SensorType::ANALOG) {
+    auto &sc = talon_controller_->GetSensorCollection();
+    int current_ticks = sc.GetAnalogIn() & 0xFFF;
+    real_ticks = current_ticks - offset_ticks;
+  }
+
   talon_controller_->SetNeutralMode(NeutralMode::Brake);
   talon_controller_->ConfigSelectedFeedbackCoefficient(1.0);
-  talon_controller_->ConfigSelectedFeedbackSensor(sensor_type_, 0, 0);
+  // Talon's virtualize a QuadEncoder from the PWM signal if no quad encoder is present. 
+  // The absolute part is set at the beginning from the SetSelectedSensorPosition
+  talon_controller_->ConfigSelectedFeedbackSensor(FeedbackDevice::QuadEncoder,
+                                                  0, 0);
   talon_controller_->EnableVoltageCompensation(true);
   talon_controller_->SetInverted(inverted_);
   talon_controller_->SetSensorPhase(invert_sensor_);
   talon_controller_->SelectProfileSlot(0, 0);
+  talon_controller_->SetSelectedSensorPosition(real_ticks, 0, 50);
   RCLCPP_INFO(debug_node_->get_logger(),
-              "%s: Successfully configured Motor Controller %d", __FUNCTION__,
-              id_);
+              "%s: Successfully configured Motor Controller %d, with offset %d",
+              __FUNCTION__, id_, real_ticks);
 }

--- a/src/HW-Devices/hardware/src/TalonSRXWrapper.cpp
+++ b/src/HW-Devices/hardware/src/TalonSRXWrapper.cpp
@@ -230,8 +230,9 @@ void TalonSRXWrapper::configure() {
 
   talon_controller_->SetNeutralMode(NeutralMode::Brake);
   talon_controller_->ConfigSelectedFeedbackCoefficient(1.0);
-  // Talon's virtualize a QuadEncoder from the PWM signal if no quad encoder is present. 
-  // The absolute part is set at the beginning from the SetSelectedSensorPosition
+  // Talon's virtualize a QuadEncoder from the PWM signal if no quad encoder is
+  // present. The absolute part is set at the beginning from the
+  // SetSelectedSensorPosition
   talon_controller_->ConfigSelectedFeedbackSensor(FeedbackDevice::QuadEncoder,
                                                   0, 0);
   talon_controller_->EnableVoltageCompensation(true);


### PR DESCRIPTION
When fixing the tuning on the arm it is important to change both the sensor offset and the limits.

I also changed how the offset is performed by making the talon handle the offset internally. I don't think its always the magnet moving, I think there was a software issue involved as well. Hopefully this helps.

This pull request updates sensor offset parameters and joint limits for the arm, and refactors the `TalonSRXWrapper` hardware abstraction to improve sensor type handling and offset application. The main focus is on standardizing how sensor offsets are managed and improving code clarity for sensor type selection and initialization.

**Key changes:**

### Sensor configuration and code refactor

* Introduced a custom `SensorType` enum in `TalonSRXWrapper` to replace the vendor-specific feedback device type, improving code clarity and maintainability. Updated all relevant logic to use this new enum. [[1]](diffhunk://#diff-5032d6b6f75c8d399bfb315c10e220eae848d5c1d3457d9465afa363e67fa783R48-R52) [[2]](diffhunk://#diff-5032d6b6f75c8d399bfb315c10e220eae848d5c1d3457d9465afa363e67fa783L56-R61) [[3]](diffhunk://#diff-3025c850128a5b886aa1e701593f6c55919f3f96a7f979710c2495124f8e31e7L17-R17) [[4]](diffhunk://#diff-3025c850128a5b886aa1e701593f6c55919f3f96a7f979710c2495124f8e31e7L102-R106)
* Refactored sensor offset handling: sensor offsets are now applied during initialization (`configure()`), and are no longer subtracted in the `write()` or added in the `read()` methods, ensuring consistent position calculations. [[1]](diffhunk://#diff-3025c850128a5b886aa1e701593f6c55919f3f96a7f979710c2495124f8e31e7L129-R129) [[2]](diffhunk://#diff-3025c850128a5b886aa1e701593f6c55919f3f96a7f979710c2495124f8e31e7L139-R139) [[3]](diffhunk://#diff-3025c850128a5b886aa1e701593f6c55919f3f96a7f979710c2495124f8e31e7R216-R244)
* In `configure()`, sensor offsets are converted to ticks and applied directly to the Talon controller at startup, with improved logging for debugging.

### Parameter and configuration updates

* Updated sensor offset parameters for several joints in `arm_urdf.ros2_control.xacro` to new values, reflecting calibration or hardware changes. [[1]](diffhunk://#diff-a9ca43a1ea11dc0786ab72f1f68075b515b3d84b0a2aace0db5a68c231c588ffL34-R34) [[2]](diffhunk://#diff-a9ca43a1ea11dc0786ab72f1f68075b515b3d84b0a2aace0db5a68c231c588ffL50-R50) [[3]](diffhunk://#diff-a9ca43a1ea11dc0786ab72f1f68075b515b3d84b0a2aace0db5a68c231c588ffL82-R82)
* Adjusted joint limits in `arm_urdf.urdf` for multiple joints to reflect new mechanical or safety constraints. [[1]](diffhunk://#diff-c9e5918f0c3c65879bd07a938bfa25778fda420fa168266b38248d2b3955ce44L159-R159) [[2]](diffhunk://#diff-c9e5918f0c3c65879bd07a938bfa25778fda420fa168266b38248d2b3955ce44L213-R213) [[3]](diffhunk://#diff-c9e5918f0c3c65879bd07a938bfa25778fda420fa168266b38248d2b3955ce44L321-R321)