### PR TITLE
Feature/srt component

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,4 +10,4 @@ find ./src -path ./src/third-party -prune -o \
 
 rosdep install --from-paths src -i -r -y
 
-colcon build --symlink-install --continue-on-error --cmake-args=-DCMAKE_BUILD_TYPE=Release --parallel-workers $(nproc)
+colcon build --symlink-install --continue-on-error --cmake-args=-DCMAKE_BUILD_TYPE=Release --parallel-workers 1

--- a/build.sh
+++ b/build.sh
@@ -10,4 +10,4 @@ find ./src -path ./src/third-party -prune -o \
 
 rosdep install --from-paths src -i -r -y
 
-colcon build --symlink-install --continue-on-error --cmake-args=-DCMAKE_BUILD_TYPE=Release --parallel-workers 1
+colcon build --symlink-install --continue-on-error --cmake-args=-DCMAKE_BUILD_TYPE=Release --parallel-workers $(nproc)

--- a/src/Cameras/video_streaming/CMakeLists.txt
+++ b/src/Cameras/video_streaming/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(video_streaming)
+project(video_streaming LANGUAGES CXX)
 
 # ---- Build settings
 set(CMAKE_CXX_STANDARD 17)
@@ -8,24 +8,20 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # ---- Dependencies
 find_package(ament_cmake REQUIRED)
-find_package(rosidl_default_generators REQUIRED)
-find_package(rosidl_default_runtime REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
-find_package(std_msgs REQUIRED)
+find_package(std_srvs REQUIRED)
 find_package(interfaces REQUIRED)
-# find_package(std_srvs REQUIRED)
 find_package(PkgConfig REQUIRED)
 
-# 1. GStreamer and GLib
 pkg_check_modules(GSTREAMER REQUIRED IMPORTED_TARGET gstreamer-1.0)
 pkg_check_modules(GST_APP REQUIRED IMPORTED_TARGET gstreamer-app-1.0)
 pkg_check_modules(GST_VIDEO REQUIRED IMPORTED_TARGET gstreamer-video-1.0)
-pkg_check_modules(GLIB REQUIRED IMPORTED_TARGET glib-2.0)
 
+add_subdirectory(gst-plugins)
 
-# ---- Build Libraries
-add_library(video_streaming_nodes SHARED
+# ---- Targets
+add_library(${PROJECT_NAME} SHARED
   src/base_video_node.cpp
   src/input_node.cpp
   src/detect_node.cpp
@@ -33,39 +29,31 @@ add_library(video_streaming_nodes SHARED
   src/srt_node.cpp
 )
 
-
-target_include_directories(video_streaming_nodes PUBLIC
-  "include" 
-  "include/${PROJECT_NAME}" 
+include_directories(
+  include/${PROJECT_NAME}
   ${GSTREAMER_INCLUDE_DIRS}
   ${GST_APP_INCLUDE_DIRS}
   ${GST_VIDEO_INCLUDE_DIRS}
-  ${GLIB_INCLUDE_DIRS}
 )
 
-
-target_link_libraries(video_streaming_nodes
+target_link_directories(${PROJECT_NAME} PRIVATE ${GST_LIBRARY_DIRS})
+target_link_libraries(${PROJECT_NAME} 
   PkgConfig::GSTREAMER
   PkgConfig::GST_APP
   PkgConfig::GST_VIDEO
-  PkgConfig::GLIB
 )
-
-
-ament_target_dependencies(video_streaming_nodes
+ament_target_dependencies(${PROJECT_NAME}
   rclcpp
   rclcpp_components
-  std_msgs
   interfaces
-  # std_srvs
+  std_srvs
 )
 
+# If pkg-config provided extra compile flags (e.g., -D, -pthread)
+target_compile_options(${PROJECT_NAME} PRIVATE ${GST_CFLAGS_OTHER})
 
-# Compiler flags form pkg-config
-target_compile_options(video_streaming_nodes PRIVATE ${GST_CFLAGS_OTHER} ${GLIB_CFLAGS_OTHER})
-
-# Register Component
-rclcpp_components_register_nodes(video_streaming_nodes 
+# Register both composable nodes
+rclcpp_components_register_nodes(${PROJECT_NAME}
   "InputNode"
   "DetectNode"
   "WebRtcNode"
@@ -74,12 +62,11 @@ rclcpp_components_register_nodes(video_streaming_nodes
 
 # ---- Install
 install(
-  TARGETS video_streaming_nodes 
+  TARGETS ${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
 )
-
 install(
   DIRECTORY include/
   DESTINATION include/
@@ -92,15 +79,14 @@ install(DIRECTORY config
   DESTINATION share/${PROJECT_NAME}
 )
 
-# ament_environment_hooks(hooks/gst_env_hook.sh)
-
-ament_export_include_directories(include)
-ament_export_dependencies(
-  rclcpp
-  rclcpp_components
-  std_msgs
-  # std_srvs
-
+# Install environment hooks so they are sourced by setup.bash
+ament_environment_hooks(
+  hooks/gst_env_hook.sh
 )
-ament_export_libraries(video_streaming_nodes) 
+
+# ---- Export
+ament_export_include_directories(include/${PROJECT_NAME})
+ament_export_dependencies(rclcpp rclcpp_components)
+ament_export_libraries(${PROJECT_NAME})
+
 ament_package()

--- a/src/Cameras/video_streaming/CMakeLists.txt
+++ b/src/Cameras/video_streaming/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.16)
-project(video_streaming LANGUAGES CXX)
+project(video_streaming)
 
 # ---- Build settings
 set(CMAKE_CXX_STANDARD 17)
@@ -8,63 +8,78 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 # ---- Dependencies
 find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(rosidl_default_runtime REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_components REQUIRED)
-find_package(std_srvs REQUIRED)
+find_package(std_msgs REQUIRED)
 find_package(interfaces REQUIRED)
+# find_package(std_srvs REQUIRED)
 find_package(PkgConfig REQUIRED)
 
+# 1. GStreamer and GLib
 pkg_check_modules(GSTREAMER REQUIRED IMPORTED_TARGET gstreamer-1.0)
 pkg_check_modules(GST_APP REQUIRED IMPORTED_TARGET gstreamer-app-1.0)
 pkg_check_modules(GST_VIDEO REQUIRED IMPORTED_TARGET gstreamer-video-1.0)
+pkg_check_modules(GLIB REQUIRED IMPORTED_TARGET glib-2.0)
 
-add_subdirectory(gst-plugins)
 
-# ---- Targets
-add_library(${PROJECT_NAME} SHARED
+# ---- Build Libraries
+add_library(video_streaming_nodes SHARED
   src/base_video_node.cpp
   src/input_node.cpp
   src/detect_node.cpp
   src/webrtc_node.cpp
+  src/srt_node.cpp
 )
 
-include_directories(
-  include/${PROJECT_NAME}
+
+target_include_directories(video_streaming_nodes PUBLIC
+  "include" 
+  "include/${PROJECT_NAME}" 
   ${GSTREAMER_INCLUDE_DIRS}
   ${GST_APP_INCLUDE_DIRS}
   ${GST_VIDEO_INCLUDE_DIRS}
+  ${GLIB_INCLUDE_DIRS}
 )
 
-target_link_directories(${PROJECT_NAME} PRIVATE ${GST_LIBRARY_DIRS})
-target_link_libraries(${PROJECT_NAME} 
+
+target_link_libraries(video_streaming_nodes
   PkgConfig::GSTREAMER
   PkgConfig::GST_APP
   PkgConfig::GST_VIDEO
+  PkgConfig::GLIB
 )
-ament_target_dependencies(${PROJECT_NAME}
+
+
+ament_target_dependencies(video_streaming_nodes
   rclcpp
   rclcpp_components
+  std_msgs
   interfaces
-  std_srvs
+  # std_srvs
 )
 
-# If pkg-config provided extra compile flags (e.g., -D, -pthread)
-target_compile_options(${PROJECT_NAME} PRIVATE ${GST_CFLAGS_OTHER})
 
-# Register both composable nodes
-rclcpp_components_register_nodes(${PROJECT_NAME}
+# Compiler flags form pkg-config
+target_compile_options(video_streaming_nodes PRIVATE ${GST_CFLAGS_OTHER} ${GLIB_CFLAGS_OTHER})
+
+# Register Component
+rclcpp_components_register_nodes(video_streaming_nodes 
   "InputNode"
   "DetectNode"
   "WebRtcNode"
+  "video_streaming::SrtNode"
 )
 
 # ---- Install
 install(
-  TARGETS ${PROJECT_NAME}
+  TARGETS video_streaming_nodes 
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
 )
+
 install(
   DIRECTORY include/
   DESTINATION include/
@@ -77,14 +92,15 @@ install(DIRECTORY config
   DESTINATION share/${PROJECT_NAME}
 )
 
-# Install environment hooks so they are sourced by setup.bash
-ament_environment_hooks(
-  hooks/gst_env_hook.sh
+# ament_environment_hooks(hooks/gst_env_hook.sh)
+
+ament_export_include_directories(include)
+ament_export_dependencies(
+  rclcpp
+  rclcpp_components
+  std_msgs
+  # std_srvs
+
 )
-
-# ---- Export
-ament_export_include_directories(include/${PROJECT_NAME})
-ament_export_dependencies(rclcpp rclcpp_components)
-ament_export_libraries(${PROJECT_NAME})
-
+ament_export_libraries(video_streaming_nodes) 
 ament_package()

--- a/src/Cameras/video_streaming/include/video_streaming/srt_node.hpp
+++ b/src/Cameras/video_streaming/include/video_streaming/srt_node.hpp
@@ -36,27 +36,6 @@ private:
   rcl_interfaces::msg::SetParametersResult
   on_parameter_change(const std::vector<rclcpp::Parameter> &parameters);
 
-  /* =========================================================
-   * TODO: FUTURE FEATURE - SRT STATISTICS
-   * Uncomment these when Srtstat.msg is available.
-   * =========================================================
-   */
-  // static void on_srt_stats(GstElement * element, GstStructure * stats,
-  // gpointer user_data);
-  // rclcpp::Publisher<video_streaming::msg::Srtstat>::SharedPtr stats_pub_;
-
-  /* =========================================================
-   * REFERENCE: CUSTOM SERVICE (Replaced by ROS 2 Parameters)
-   * Kept for reference in case specific service control is needed later.
-   * =========================================================
-   */
-  // void on_set_params(
-  //   const std::shared_ptr<video_streaming::srv::SetStreamingParams::Request>
-  //   request,
-  //   std::shared_ptr<video_streaming::srv::SetStreamingParams::Response>
-  //   response);
-  // rclcpp::Service<video_streaming::srv::SetStreamingParams>::SharedPtr
-  // params_srv_;
 };
 
 } // namespace video_streaming

--- a/src/Cameras/video_streaming/include/video_streaming/srt_node.hpp
+++ b/src/Cameras/video_streaming/include/video_streaming/srt_node.hpp
@@ -1,57 +1,62 @@
 #pragma once
 #include "base_video_node.hpp"
-#include <gst/gst.h>
 #include "rclcpp/rclcpp.hpp"
-#include "std_msgs/msg/int32.hpp"  //bitrate
-#include "std_msgs/msg/empty.hpp"  //I-frame
+#include "std_msgs/msg/empty.hpp" // I-frame
+#include "std_msgs/msg/int32.hpp" // bitrate
+#include <gst/gst.h>
 
+namespace video_streaming {
 
-
-namespace video_streaming
-
-{
 class SrtNode : public BaseVideoNode {
 public:
-  explicit SrtNode(
-            const rclcpp::NodeOptions &options = rclcpp::NodeOptions());            
+  explicit SrtNode(const rclcpp::NodeOptions &options = rclcpp::NodeOptions());
   ~SrtNode() override = default;
 
 protected:
   // (interpipesrc -> nvvidconv -> nvv4l2av1enc -> srtsink)
   bool create_pipeline() override;
 
-  GstElement * av1_encoder_ = nullptr;
-  GstElement * srt_sink_ = nullptr;
+  GstElement *av1_encoder_ = nullptr;
+  GstElement *srt_sink_ = nullptr;
 
-
-  //bitrate
+  // bitrate
   rclcpp::Subscription<std_msgs::msg::Int32>::SharedPtr bitrate_sub_;
 
   // I-frame
   rclcpp::Subscription<std_msgs::msg::Empty>::SharedPtr iframe_sub_;
-  
+
+  // Parameter callback handle
   rclcpp::Node::OnSetParametersCallbackHandle::SharedPtr param_callback_handle_;
 
-  // rclcpp::Publisher<video_streaming::msg::Srtstat>::SharedPtr stats_pub_;
-
 private:
-
   void on_bitrate_received(const std_msgs::msg::Int32::SharedPtr msg);
 
   void on_iframe_trigger(const std_msgs::msg::Empty::SharedPtr msg);
 
-  rcl_interfaces::msg::SetParametersResult on_parameter_change(
-      const std::vector<rclcpp::Parameter> &parameters);
-
+  rcl_interfaces::msg::SetParametersResult
+  on_parameter_change(const std::vector<rclcpp::Parameter> &parameters);
 
   /* =========================================================
    * TODO: FUTURE FEATURE - SRT STATISTICS
    * Uncomment these when Srtstat.msg is available.
    * =========================================================
    */
-  // static void on_srt_stats(GstElement * element, GstStructure * stats, gpointer user_data);
+  // static void on_srt_stats(GstElement * element, GstStructure * stats,
+  // gpointer user_data);
   // rclcpp::Publisher<video_streaming::msg::Srtstat>::SharedPtr stats_pub_;
 
+  /* =========================================================
+   * REFERENCE: CUSTOM SERVICE (Replaced by ROS 2 Parameters)
+   * Kept for reference in case specific service control is needed later.
+   * =========================================================
+   */
+  // void on_set_params(
+  //   const std::shared_ptr<video_streaming::srv::SetStreamingParams::Request>
+  //   request,
+  //   std::shared_ptr<video_streaming::srv::SetStreamingParams::Response>
+  //   response);
+  // rclcpp::Service<video_streaming::srv::SetStreamingParams>::SharedPtr
+  // params_srv_;
 };
 
-} 
+} // namespace video_streaming

--- a/src/Cameras/video_streaming/include/video_streaming/srt_node.hpp
+++ b/src/Cameras/video_streaming/include/video_streaming/srt_node.hpp
@@ -35,7 +35,6 @@ private:
 
   rcl_interfaces::msg::SetParametersResult
   on_parameter_change(const std::vector<rclcpp::Parameter> &parameters);
-
 };
 
 } // namespace video_streaming

--- a/src/Cameras/video_streaming/include/video_streaming/srt_node.hpp
+++ b/src/Cameras/video_streaming/include/video_streaming/srt_node.hpp
@@ -1,0 +1,57 @@
+#pragma once
+#include "base_video_node.hpp"
+#include <gst/gst.h>
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/int32.hpp"  //bitrate
+#include "std_msgs/msg/empty.hpp"  //I-frame
+
+
+
+namespace video_streaming
+
+{
+class SrtNode : public BaseVideoNode {
+public:
+  explicit SrtNode(
+            const rclcpp::NodeOptions &options = rclcpp::NodeOptions());            
+  ~SrtNode() override = default;
+
+protected:
+  // (interpipesrc -> nvvidconv -> nvv4l2av1enc -> srtsink)
+  bool create_pipeline() override;
+
+  GstElement * av1_encoder_ = nullptr;
+  GstElement * srt_sink_ = nullptr;
+
+
+  //bitrate
+  rclcpp::Subscription<std_msgs::msg::Int32>::SharedPtr bitrate_sub_;
+
+  // I-frame
+  rclcpp::Subscription<std_msgs::msg::Empty>::SharedPtr iframe_sub_;
+  
+  rclcpp::Node::OnSetParametersCallbackHandle::SharedPtr param_callback_handle_;
+
+  // rclcpp::Publisher<video_streaming::msg::Srtstat>::SharedPtr stats_pub_;
+
+private:
+
+  void on_bitrate_received(const std_msgs::msg::Int32::SharedPtr msg);
+
+  void on_iframe_trigger(const std_msgs::msg::Empty::SharedPtr msg);
+
+  rcl_interfaces::msg::SetParametersResult on_parameter_change(
+      const std::vector<rclcpp::Parameter> &parameters);
+
+
+  /* =========================================================
+   * TODO: FUTURE FEATURE - SRT STATISTICS
+   * Uncomment these when Srtstat.msg is available.
+   * =========================================================
+   */
+  // static void on_srt_stats(GstElement * element, GstStructure * stats, gpointer user_data);
+  // rclcpp::Publisher<video_streaming::msg::Srtstat>::SharedPtr stats_pub_;
+
+};
+
+} 

--- a/src/Cameras/video_streaming/launch/video_streaming.launch.py
+++ b/src/Cameras/video_streaming/launch/video_streaming.launch.py
@@ -33,19 +33,16 @@ def generate_launch_description():
         namespace="",
         parameters=[],
     )
-    
+
     srt_node = ComposableNode(
         package="video_streaming",
-        plugin="video_streaming::SrtNode", 
+        plugin="video_streaming::SrtNode",
         name="srt_node",
         namespace="",
-        parameters=[{
-            "srt_uri": "srt://127.0.0.1:12345",
-            "latency": 100,          
-            "iframe_interval": 30    
-        }],
+        parameters=[
+            {"srt_uri": "srt://127.0.0.1:12345", "latency": 100, "iframe_interval": 30}
+        ],
     )
-
 
     # Create a container for all 3 components
     container = ComposableNodeContainer(

--- a/src/Cameras/video_streaming/launch/video_streaming.launch.py
+++ b/src/Cameras/video_streaming/launch/video_streaming.launch.py
@@ -40,7 +40,7 @@ def generate_launch_description():
         name="srt_node",
         namespace="",
         parameters=[
-            {"srt_uri": "srt://127.0.0.1:12345", "latency": 100, "iframe_interval": 30}
+            {"srt_uri": "srt://127.0.0.1:7001", "latency": 100, "iframe_interval": 30}
         ],
     )
 

--- a/src/Cameras/video_streaming/launch/video_streaming.launch.py
+++ b/src/Cameras/video_streaming/launch/video_streaming.launch.py
@@ -39,9 +39,7 @@ def generate_launch_description():
         plugin="video_streaming::SrtNode",
         name="srt_node",
         namespace="",
-        parameters=[
-            {"srt_uri": "srt://:7001", "latency": 100, "iframe_interval": 30}
-        ],
+        parameters=[{"srt_uri": "srt://:7001", "latency": 100, "iframe_interval": 30}],
     )
 
     # Create a container for all 3 components

--- a/src/Cameras/video_streaming/launch/video_streaming.launch.py
+++ b/src/Cameras/video_streaming/launch/video_streaming.launch.py
@@ -33,6 +33,19 @@ def generate_launch_description():
         namespace="",
         parameters=[],
     )
+    
+    srt_node = ComposableNode(
+        package="video_streaming",
+        plugin="video_streaming::SrtNode", 
+        name="srt_node",
+        namespace="",
+        parameters=[{
+            "srt_uri": "srt://127.0.0.1:12345",
+            "latency": 100,          
+            "iframe_interval": 30    
+        }],
+    )
+
 
     # Create a container for all 3 components
     container = ComposableNodeContainer(
@@ -44,6 +57,7 @@ def generate_launch_description():
             input_node,
             detect_node,
             streaming_node,
+            srt_node,
         ],
         output="screen",
     )

--- a/src/Cameras/video_streaming/launch/video_streaming.launch.py
+++ b/src/Cameras/video_streaming/launch/video_streaming.launch.py
@@ -40,7 +40,7 @@ def generate_launch_description():
         name="srt_node",
         namespace="",
         parameters=[
-            {"srt_uri": "srt://127.0.0.1:7001", "latency": 100, "iframe_interval": 30}
+            {"srt_uri": "srt://:7001", "latency": 100, "iframe_interval": 30}
         ],
     )
 

--- a/src/Cameras/video_streaming/package.xml
+++ b/src/Cameras/video_streaming/package.xml
@@ -7,27 +7,17 @@
   <maintainer email="connor.needham2015@gmail.com">connor</maintainer>
   <license>Apache-2.0</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
-  <!-- <buildtool_depend>rosidl_default_generators</buildtool_depend> -->
+<buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>pkg-config</buildtool_depend>
 
-  <build_depend>rclcpp</build_depend>
-  <build_depend>rclcpp_components</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <!-- <build_depend>std_srvs</build_depend> -->
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+  <depend>std_msgs</depend>
+  <!-- <depend>std_srvs</depend> -->
+  <depend>gstreamer-1.0</depend>
+  <depend>glib-2.0</depend>
+
   <build_depend>interfaces</build_depend>
-  <build_depend>gstreamer-1.0</build_depend>
-  <build_depend>glib-2.0</build_depend>
-
-  <exec_depend>rclcpp</exec_depend>
-  <exec_depend>rclcpp_components</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
-  <exec_depend>std_srvs</exec_depend>
-  <!-- <exec_depend>rosidl_default_runtime</exec_depend> -->
-  <exec_depend>gstreamer-1.0</exec_depend>
-  <exec_depend>glib-2.0</exec_depend>
-
-  <!-- <member_of_group>rosidl_interface_packages</member_of_group> -->
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/Cameras/video_streaming/package.xml
+++ b/src/Cameras/video_streaming/package.xml
@@ -3,14 +3,31 @@
 <package format="3">
   <name>video_streaming</name>
   <version>0.0.0</version>
-  <description>TODO: Package description</description>
+  <description>Video streaming package with SRT and GStreamer</description>
   <maintainer email="connor.needham2015@gmail.com">connor</maintainer>
-  <license>TODO: License declaration</license>
+  <license>Apache-2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <depend>rclcpp</depend>
-  <depend>interfaces</depend>
-  <depend>std_srvs</depend>
+  <!-- <buildtool_depend>rosidl_default_generators</buildtool_depend> -->
+  <buildtool_depend>pkg-config</buildtool_depend>
+
+  <build_depend>rclcpp</build_depend>
+  <build_depend>rclcpp_components</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <!-- <build_depend>std_srvs</build_depend> -->
+  <build_depend>interfaces</build_depend>
+  <build_depend>gstreamer-1.0</build_depend>
+  <build_depend>glib-2.0</build_depend>
+
+  <exec_depend>rclcpp</exec_depend>
+  <exec_depend>rclcpp_components</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+  <exec_depend>std_srvs</exec_depend>
+  <!-- <exec_depend>rosidl_default_runtime</exec_depend> -->
+  <exec_depend>gstreamer-1.0</exec_depend>
+  <exec_depend>glib-2.0</exec_depend>
+
+  <!-- <member_of_group>rosidl_interface_packages</member_of_group> -->
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/src/Cameras/video_streaming/src/srt_node.cpp
+++ b/src/Cameras/video_streaming/src/srt_node.cpp
@@ -38,6 +38,7 @@ SrtNode::SrtNode(const rclcpp::NodeOptions &options)
 bool SrtNode::create_pipeline() {
   std::string srt_uri = this->get_parameter("srt_uri").as_string();
   int latency_val = this->get_parameter("latency").as_int();
+  int iframe_interval_val = this->get_parameter("iframe_interval").as_int();
 
   bool test_mode = this->get_parameter("test_mode").as_bool();
 
@@ -50,18 +51,21 @@ bool SrtNode::create_pipeline() {
         "x264enc tune=zerolatency bitrate=2000 speed-preset=ultrafast "
         "name=av1_enc ! "
         "rtph264pay ! queue ! "
-        "srtsink name=srt_sink uri=%s latency=%d mode=1",
+        "srtsink name=srt_sink uri=%s latency=%d",
         srt_uri.c_str(), latency_val);
     RCLCPP_WARN(this->get_logger(), "Using MAC TEST pipeline description: %s",
                 desc);
 
   } else {
-    desc = g_strdup_printf("interpipesrc listen-to=detect ! "
-                           "nvvidconv ! "
-                           "nvv4l2av1enc name=av1_enc ! "
-                           "rtpav1pay ! queue ! "
-                           "srtsink name=srt_sink uri=%s latency=%d mode=1",
-                           srt_uri.c_str(), latency_val);
+    desc = g_strdup_printf(
+        "interpipesrc listen-to=detect ! "
+        "nvvidconv ! "
+        "nvv4l2av1enc name=av1_enc insert-seq-hdr=true iframeinterval=%d ! "
+        " av1parse ! capsfilter caps=\"video/x-av1, "
+        "alignment=obu, parsed=true\" ! "
+        "queue ! "
+        "srtsink name=srt_sink uri=%s latency=%d",
+        iframe_interval_val, srt_uri.c_str(), latency_val);
     RCLCPP_INFO(this->get_logger(), "Using PRODUCTION pipeline description: %s",
                 desc);
   }
@@ -131,7 +135,7 @@ void SrtNode::on_bitrate_received(const std_msgs::msg::Int32::SharedPtr msg) {
 void SrtNode::on_iframe_trigger(const std_msgs::msg::Empty::SharedPtr msg) {
   (void)msg;
   if (av1_encoder_) {
-    g_signal_emit_by_name(av1_encoder_, "force-key-unit", NULL);
+    g_signal_emit_by_name(av1_encoder_, "force-IDR", NULL);
     RCLCPP_INFO(this->get_logger(), "I-Frame triggered");
   }
 }

--- a/src/Cameras/video_streaming/src/srt_node.cpp
+++ b/src/Cameras/video_streaming/src/srt_node.cpp
@@ -12,9 +12,10 @@ SrtNode::SrtNode(const rclcpp::NodeOptions &options)
 
   // Start up
   // latency , iframe_interval
-  this->declare_parameter<std::string>("srt_uri", "srt://127.0.0.1:7001");
+  this->declare_parameter<std::string>("srt_uri", "srt://:7001");
   this->declare_parameter<int>("latency", 100);
   this->declare_parameter<int>("iframe_interval", 0);
+  this->declare_parameter<bool>("test_mode", false);
 
   param_callback_handle_ = this->add_on_set_parameters_callback(
       std::bind(&SrtNode::on_parameter_change, this, std::placeholders::_1));
@@ -38,12 +39,7 @@ bool SrtNode::create_pipeline() {
   std::string srt_uri = this->get_parameter("srt_uri").as_string();
   int latency_val = this->get_parameter("latency").as_int();
 
-  bool test_mode = false;
-  try {
-    test_mode = this->get_parameter("test_mode").as_bool();
-  } catch (...) {
-    test_mode = this->declare_parameter<bool>("test_mode", false);
-  }
+  bool test_mode = this->get_parameter("test_mode").as_bool();
 
   gchar *desc;
 

--- a/src/Cameras/video_streaming/src/srt_node.cpp
+++ b/src/Cameras/video_streaming/src/srt_node.cpp
@@ -12,7 +12,7 @@ SrtNode::SrtNode(const rclcpp::NodeOptions &options)
 
   // Start up
   // latency , iframe_interval
-  this->declare_parameter<std::string>("srt_uri", "srt://127.0.0.1:12345");
+  this->declare_parameter<std::string>("srt_uri", "srt://127.0.0.1:7001");
   this->declare_parameter<int>("latency", 100);
   this->declare_parameter<int>("iframe_interval", 0);
 
@@ -38,26 +38,37 @@ bool SrtNode::create_pipeline() {
   std::string srt_uri = this->get_parameter("srt_uri").as_string();
   int latency_val = this->get_parameter("latency").as_int();
 
-  gchar *desc =
-      g_strdup_printf("interpipesrc listen-to=detect ! "
-                      "nvvidconv ! "
-                      "nvv4l2av1enc name=av1_enc ! "
-                      "rtpav1pay ! queue ! "
+  bool test_mode = false;
+  try{
+    test_mode = this->get_parameter("test_mode").as_bool();
+  } catch(...) {
+    test_mode = this->declare_parameter<bool>("test_mode", false);
+  }
+
+  gchar *desc;
+
+  if(test_mode){
+    desc = g_strdup_printf("videotestsrc is-live=true ! video/x-raw,width=640,height=480 ! "
+                           "videoconvert ! "
+                           "x264enc tune=zerolatency bitrate=2000 speed-preset=ultrafast name=av1_enc ! "
+                           "rtph264pay ! queue ! "
+                           "srtsink name=srt_sink uri=%s latency=%d mode=1",
+                           srt_uri.c_str(), latency_val);
+    RCLCPP_WARN(this->get_logger(), "Using MAC TEST pipeline description: %s", desc);
+
+  } else {
+    desc = g_strdup_printf("interpipesrc listen-to=detect ! "
+                           "nvvidconv ! "
+                           "nvv4l2av1enc name=av1_enc ! "
+                           "rtpav1pay ! queue ! "
                       "srtsink name=srt_sink uri=%s latency=%d mode=1",
                       srt_uri.c_str(), latency_val);
+    RCLCPP_INFO(this->get_logger(), "Using PRODUCTION pipeline description: %s",
+                 desc);
+    }
+    RCLCPP_INFO(this->get_logger(), "Pipeline description: %s",
+                desc);
 
-  /* // [MAC TEST MODE]
-    gchar *desc = g_strdup_printf(
-        "videotestsrc is-live=true ! video/x-raw,width=640,height=480 ! "
-        "videoconvert ! "
-        "x264enc tune=zerolatency bitrate=2000 speed-preset=ultrafast
-    name=av1_enc ! " "rtph264pay ! queue ! " "srtsink name=srt_sink uri=%s
-    latency=%d mode=1", srt_uri.c_str(), latency_val
-    );
-    */
-
-  RCLCPP_INFO(this->get_logger(), "Using PRODUCTION pipeline description: %s",
-              desc);
 
   GError *err = nullptr;
   GstElement *p = gst_parse_launch(desc, &err);
@@ -126,85 +137,6 @@ void SrtNode::on_iframe_trigger(const std_msgs::msg::Empty::SharedPtr msg) {
     RCLCPP_INFO(this->get_logger(), "I-Frame triggered");
   }
 }
-
-/* ==================================================================================
- * TODO: FUTURE FEATURE - SRT STATISTICS & SERVICE
- * * The following code implements SRT statistics publishing and a custom
- * service.
- * * Per feedback, we are currently pausing this functionality to focus on the
- * video
- * * pipeline and using ROS 2 Parameters for control.
- * * Once custom .msg and .srv files are added to the interfaces package,
- * * uncomment this block and the corresponding headers.
- * ==================================================================================
- */
-
-/*
-// void SrtNode::on_srt_stats(GstElement * element, GstStructure * stats,
-gpointer user_data)
-// {
-//     SrtNode* node = static_cast<SrtNode*>(user_data);
-//     if (!node) return;
-
-//     video_streaming::msg::Srtstat stats_msg;
-//     if (!stats) {
-//         RCLCPP_WARN(node->get_logger(), "on_srt_stats called with null
-GstStructure");
-//         node->stats_pub_->publish(stats_msg);
-//         return;
-//     }
-
-//     // Debug: print the full structure to discover actual key names & units
-//     gchar *s = gst_structure_to_string(stats);
-//     RCLCPP_DEBUG(node->get_logger(), "SRT stats structure: %s", s);
-//     g_free(s);
-
-//     // rtt -> Srtstat.rtt (seconds)
-//     double rtt_double = 0.0;
-//     gint rtt_int = 0;
-//     if (gst_structure_get_double(stats, "rtt", &rtt_double)) {
-//         // assume already in seconds
-//         stats_msg.rtt = rtt_double;
-//     } else if (gst_structure_get_int(stats, "rtt", &rtt_int)) {
-//         // some sources report ms as integer — convert to seconds
-//         stats_msg.rtt = static_cast<double>(rtt_int) / 1000.0;
-//     }
-
-//     // bandwidth -> Srtstat.bandwidth (bits/sec)
-//     double bw_double = 0.0;
-//     gint bw_int = 0;
-//     if (gst_structure_get_double(stats, "bandwidth", &bw_double)) {
-//         stats_msg.bandwidth = bw_double;
-//     } else if (gst_structure_get_int(stats, "bandwidth", &bw_int)) {
-//         stats_msg.bandwidth = static_cast<double>(bw_int);
-//     }
-
-//     // packets_sent -> Srtstat.packets_sent
-//     gint packets_sent = 0;
-//     if (gst_structure_get_int(stats, "packets-sent", &packets_sent) ||
-//         gst_structure_get_int(stats, "packets_sent", &packets_sent)) {
-//         stats_msg.packets_sent = static_cast<int64_t>(packets_sent);
-//     }
-
-//     // packets_lost -> Srtstat.packets_lost
-//     gint packets_lost = 0;
-//     if (gst_structure_get_int(stats, "packets-lost", &packets_lost) ||
-//         gst_structure_get_int(stats, "packets_lost", &packets_lost)) {
-//         stats_msg.packets_lost = static_cast<int64_t>(packets_lost);
-//     }
-
-//     // packets_retransmitted -> Srtstat.packets_retransmitted
-//     gint packets_retx = 0;
-//     if (gst_structure_get_int(stats, "packets-retransmitted", &packets_retx)
-||
-//         gst_structure_get_int(stats, "packets_retransmitted", &packets_retx))
-{
-//         stats_msg.packets_retransmitted = static_cast<int64_t>(packets_retx);
-//     }
-
-//     node->stats_pub_->publish(stats_msg);
-// }
-*/
 
 } // namespace video_streaming
 

--- a/src/Cameras/video_streaming/src/srt_node.cpp
+++ b/src/Cameras/video_streaming/src/srt_node.cpp
@@ -4,11 +4,10 @@
 #include <glib.h>
 #include <rclcpp_components/register_node_macro.hpp>
 
-namespace video_streaming
-{
+namespace video_streaming {
 
-SrtNode::SrtNode(const rclcpp::NodeOptions & options) : BaseVideoNode("srt_node", options)
-{
+SrtNode::SrtNode(const rclcpp::NodeOptions &options)
+    : BaseVideoNode("srt_node", options) {
   RCLCPP_INFO(this->get_logger(), "Initializing SrtNode...");
 
   // Start up
@@ -18,13 +17,15 @@ SrtNode::SrtNode(const rclcpp::NodeOptions & options) : BaseVideoNode("srt_node"
   this->declare_parameter<int>("iframe_interval", 0);
 
   param_callback_handle_ = this->add_on_set_parameters_callback(
-    std::bind(&SrtNode::on_parameter_change, this, std::placeholders::_1));
+      std::bind(&SrtNode::on_parameter_change, this, std::placeholders::_1));
 
   bitrate_sub_ = this->create_subscription<std_msgs::msg::Int32>(
-    "~/set_bitrate", 10, std::bind(&SrtNode::on_bitrate_received, this, std::placeholders::_1));
+      "~/set_bitrate", 10,
+      std::bind(&SrtNode::on_bitrate_received, this, std::placeholders::_1));
 
   iframe_sub_ = this->create_subscription<std_msgs::msg::Empty>(
-    "~/trigger_iframe", 10, std::bind(&SrtNode::on_iframe_trigger, this, std::placeholders::_1));
+      "~/trigger_iframe", 10,
+      std::bind(&SrtNode::on_iframe_trigger, this, std::placeholders::_1));
 
   if (!start_pipeline()) {
     RCLCPP_FATAL(get_logger(), "SrtNode: failed to start pipeline.");
@@ -33,42 +34,40 @@ SrtNode::SrtNode(const rclcpp::NodeOptions & options) : BaseVideoNode("srt_node"
   RCLCPP_INFO(get_logger(), "SrtNode constructed and pipeline started.");
 }
 
-bool SrtNode::create_pipeline()
-{
+bool SrtNode::create_pipeline() {
   std::string srt_uri = this->get_parameter("srt_uri").as_string();
   int latency_val = this->get_parameter("latency").as_int();
 
-  // ✅ PRODUCTION MODE (NVIDIA Jetson)
-  // Added comma correctly below
-  gchar * desc = g_strdup_printf(
-    "interpipesrc listen-to=detect ! "
-    "nvvidconv ! "
-    "nvv4l2av1enc name=av1_enc ! "
-    "rtpav1pay ! queue ! "
-    "srtsink name=srt_sink uri=%s latency=%d mode=1",
-    srt_uri.c_str(), latency_val);
+  gchar *desc =
+      g_strdup_printf("interpipesrc listen-to=detect ! "
+                      "nvvidconv ! "
+                      "nvv4l2av1enc name=av1_enc ! "
+                      "rtpav1pay ! queue ! "
+                      "srtsink name=srt_sink uri=%s latency=%d mode=1",
+                      srt_uri.c_str(), latency_val);
 
   /* // [MAC TEST MODE]
     gchar *desc = g_strdup_printf(
         "videotestsrc is-live=true ! video/x-raw,width=640,height=480 ! "
         "videoconvert ! "
-        "x264enc tune=zerolatency bitrate=2000 speed-preset=ultrafast name=av1_enc ! "
-        "rtph264pay ! queue ! "
-        "srtsink name=srt_sink uri=%s latency=%d mode=1",
-        srt_uri.c_str(),
-        latency_val
+        "x264enc tune=zerolatency bitrate=2000 speed-preset=ultrafast
+    name=av1_enc ! " "rtph264pay ! queue ! " "srtsink name=srt_sink uri=%s
+    latency=%d mode=1", srt_uri.c_str(), latency_val
     );
     */
 
-  RCLCPP_INFO(this->get_logger(), "Using PRODUCTION pipeline description: %s", desc);
+  RCLCPP_INFO(this->get_logger(), "Using PRODUCTION pipeline description: %s",
+              desc);
 
-  GError * err = nullptr;
-  GstElement * p = gst_parse_launch(desc, &err);
+  GError *err = nullptr;
+  GstElement *p = gst_parse_launch(desc, &err);
   g_free(desc);
 
   if (err || !p) {
-    RCLCPP_ERROR(get_logger(), "gst_parse_launch failed: %s", err ? err->message : "unknown");
-    if (err) g_error_free(err);
+    RCLCPP_ERROR(get_logger(), "gst_parse_launch failed: %s",
+                 err ? err->message : "unknown");
+    if (err)
+      g_error_free(err);
     return false;
   }
   if (!GST_IS_PIPELINE(p)) {
@@ -86,42 +85,41 @@ bool SrtNode::create_pipeline()
     return false;
   }
 
-  RCLCPP_INFO(this->get_logger(), "Pipeline parsed and elements retrieved successfully.");
+  RCLCPP_INFO(this->get_logger(),
+              "Pipeline parsed and elements retrieved successfully.");
   return true;
 }
 
-rcl_interfaces::msg::SetParametersResult SrtNode::on_parameter_change(
-  const std::vector<rclcpp::Parameter> & parameters)
-{
+rcl_interfaces::msg::SetParametersResult
+SrtNode::on_parameter_change(const std::vector<rclcpp::Parameter> &parameters) {
   rcl_interfaces::msg::SetParametersResult result;
   result.successful = true;
   result.reason = "success";
 
-  for (const auto & param : parameters) {
+  for (const auto &param : parameters) {
     if (param.get_name() == "latency" && srt_sink_) {
       int val = param.as_int();
       g_object_set(srt_sink_, "latency", val, NULL);
       RCLCPP_INFO(this->get_logger(), "Param Update: Latency set to %d", val);
     } else if (param.get_name() == "iframe_interval" && av1_encoder_) {
       int val = param.as_int();
-      // ✅ Production property name: iframeinterval
+
       g_object_set(av1_encoder_, "iframeinterval", val, NULL);
-      RCLCPP_INFO(this->get_logger(), "Param Update: IFrame Interval set to %d", val);
+      RCLCPP_INFO(this->get_logger(), "Param Update: IFrame Interval set to %d",
+                  val);
     }
   }
   return result;
 }
 
-void SrtNode::on_bitrate_received(const std_msgs::msg::Int32::SharedPtr msg)
-{
+void SrtNode::on_bitrate_received(const std_msgs::msg::Int32::SharedPtr msg) {
   if (av1_encoder_) {
     g_object_set(av1_encoder_, "bitrate", msg->data, NULL);
     RCLCPP_INFO(this->get_logger(), "Bitrate set to %d", msg->data);
   }
 }
 
-void SrtNode::on_iframe_trigger(const std_msgs::msg::Empty::SharedPtr msg)
-{
+void SrtNode::on_iframe_trigger(const std_msgs::msg::Empty::SharedPtr msg) {
   (void)msg;
   if (av1_encoder_) {
     g_signal_emit_by_name(av1_encoder_, "force-key-unit", NULL);
@@ -131,8 +129,10 @@ void SrtNode::on_iframe_trigger(const std_msgs::msg::Empty::SharedPtr msg)
 
 /* ==================================================================================
  * TODO: FUTURE FEATURE - SRT STATISTICS & SERVICE
- * * The following code implements SRT statistics publishing and a custom service.
- * * Per feedback, we are currently pausing this functionality to focus on the video
+ * * The following code implements SRT statistics publishing and a custom
+ * service.
+ * * Per feedback, we are currently pausing this functionality to focus on the
+ * video
  * * pipeline and using ROS 2 Parameters for control.
  * * Once custom .msg and .srv files are added to the interfaces package,
  * * uncomment this block and the corresponding headers.
@@ -140,14 +140,16 @@ void SrtNode::on_iframe_trigger(const std_msgs::msg::Empty::SharedPtr msg)
  */
 
 /*
-// void SrtNode::on_srt_stats(GstElement * element, GstStructure * stats, gpointer user_data)
+// void SrtNode::on_srt_stats(GstElement * element, GstStructure * stats,
+gpointer user_data)
 // {
 //     SrtNode* node = static_cast<SrtNode*>(user_data);
 //     if (!node) return;
 
 //     video_streaming::msg::Srtstat stats_msg;
 //     if (!stats) {
-//         RCLCPP_WARN(node->get_logger(), "on_srt_stats called with null GstStructure");
+//         RCLCPP_WARN(node->get_logger(), "on_srt_stats called with null
+GstStructure");
 //         node->stats_pub_->publish(stats_msg);
 //         return;
 //     }
@@ -193,8 +195,10 @@ void SrtNode::on_iframe_trigger(const std_msgs::msg::Empty::SharedPtr msg)
 
 //     // packets_retransmitted -> Srtstat.packets_retransmitted
 //     gint packets_retx = 0;
-//     if (gst_structure_get_int(stats, "packets-retransmitted", &packets_retx) ||
-//         gst_structure_get_int(stats, "packets_retransmitted", &packets_retx)) {
+//     if (gst_structure_get_int(stats, "packets-retransmitted", &packets_retx)
+||
+//         gst_structure_get_int(stats, "packets_retransmitted", &packets_retx))
+{
 //         stats_msg.packets_retransmitted = static_cast<int64_t>(packets_retx);
 //     }
 
@@ -202,6 +206,6 @@ void SrtNode::on_iframe_trigger(const std_msgs::msg::Empty::SharedPtr msg)
 // }
 */
 
-}  // namespace video_streaming
+} // namespace video_streaming
 
 RCLCPP_COMPONENTS_REGISTER_NODE(video_streaming::SrtNode)

--- a/src/Cameras/video_streaming/src/srt_node.cpp
+++ b/src/Cameras/video_streaming/src/srt_node.cpp
@@ -4,12 +4,10 @@
 #include <glib.h>
 #include <rclcpp_components/register_node_macro.hpp>
 
-namespace video_streaming
-{
+namespace video_streaming {
 
-SrtNode::SrtNode(const rclcpp::NodeOptions & options)
-: BaseVideoNode("srt_node", options)
-{
+SrtNode::SrtNode(const rclcpp::NodeOptions &options)
+    : BaseVideoNode("srt_node", options) {
   RCLCPP_INFO(this->get_logger(), "Initializing SrtNode...");
 
   // Start up
@@ -20,15 +18,15 @@ SrtNode::SrtNode(const rclcpp::NodeOptions & options)
   this->declare_parameter<bool>("test_mode", false);
 
   param_callback_handle_ = this->add_on_set_parameters_callback(
-    std::bind(&SrtNode::on_parameter_change, this, std::placeholders::_1));
+      std::bind(&SrtNode::on_parameter_change, this, std::placeholders::_1));
 
   bitrate_sub_ = this->create_subscription<std_msgs::msg::Int32>(
-    "~/set_bitrate", 10,
-    std::bind(&SrtNode::on_bitrate_received, this, std::placeholders::_1));
+      "~/set_bitrate", 10,
+      std::bind(&SrtNode::on_bitrate_received, this, std::placeholders::_1));
 
   iframe_sub_ = this->create_subscription<std_msgs::msg::Empty>(
-    "~/trigger_iframe", 10,
-    std::bind(&SrtNode::on_iframe_trigger, this, std::placeholders::_1));
+      "~/trigger_iframe", 10,
+      std::bind(&SrtNode::on_iframe_trigger, this, std::placeholders::_1));
 
   if (!start_pipeline()) {
     RCLCPP_FATAL(get_logger(), "SrtNode: failed to start pipeline.");
@@ -37,50 +35,45 @@ SrtNode::SrtNode(const rclcpp::NodeOptions & options)
   RCLCPP_INFO(get_logger(), "SrtNode constructed and pipeline started.");
 }
 
-bool SrtNode::create_pipeline()
-{
+bool SrtNode::create_pipeline() {
   std::string srt_uri = this->get_parameter("srt_uri").as_string();
   int latency_val = this->get_parameter("latency").as_int();
 
   bool test_mode = this->get_parameter("test_mode").as_bool();
 
-  gchar * desc;
+  gchar *desc;
 
   if (test_mode) {
     desc = g_strdup_printf(
-      "videotestsrc is-live=true ! video/x-raw,width=640,height=480 ! "
-      "videoconvert ! "
-      "x264enc tune=zerolatency bitrate=2000 speed-preset=ultrafast "
-      "name=av1_enc ! "
-      "rtph264pay ! queue ! "
-      "srtsink name=srt_sink uri=%s latency=%d mode=1",
-      srt_uri.c_str(), latency_val);
-    RCLCPP_WARN(
-      this->get_logger(), "Using MAC TEST pipeline description: %s",
-      desc);
+        "videotestsrc is-live=true ! video/x-raw,width=640,height=480 ! "
+        "videoconvert ! "
+        "x264enc tune=zerolatency bitrate=2000 speed-preset=ultrafast "
+        "name=av1_enc ! "
+        "rtph264pay ! queue ! "
+        "srtsink name=srt_sink uri=%s latency=%d mode=1",
+        srt_uri.c_str(), latency_val);
+    RCLCPP_WARN(this->get_logger(), "Using MAC TEST pipeline description: %s",
+                desc);
 
   } else {
-    desc = g_strdup_printf(
-      "interpipesrc listen-to=detect ! "
-      "nvvidconv ! "
-      "nvv4l2av1enc name=av1_enc ! "
-      "rtpav1pay ! queue ! "
-      "srtsink name=srt_sink uri=%s latency=%d mode=1",
-      srt_uri.c_str(), latency_val);
-    RCLCPP_INFO(
-      this->get_logger(), "Using PRODUCTION pipeline description: %s",
-      desc);
+    desc = g_strdup_printf("interpipesrc listen-to=detect ! "
+                           "nvvidconv ! "
+                           "nvv4l2av1enc name=av1_enc ! "
+                           "rtpav1pay ! queue ! "
+                           "srtsink name=srt_sink uri=%s latency=%d mode=1",
+                           srt_uri.c_str(), latency_val);
+    RCLCPP_INFO(this->get_logger(), "Using PRODUCTION pipeline description: %s",
+                desc);
   }
   RCLCPP_INFO(this->get_logger(), "Pipeline description: %s", desc);
 
-  GError * err = nullptr;
-  GstElement * p = gst_parse_launch(desc, &err);
+  GError *err = nullptr;
+  GstElement *p = gst_parse_launch(desc, &err);
   g_free(desc);
 
   if (err || !p) {
-    RCLCPP_ERROR(
-      get_logger(), "gst_parse_launch failed: %s",
-      err ? err->message : "unknown");
+    RCLCPP_ERROR(get_logger(), "gst_parse_launch failed: %s",
+                 err ? err->message : "unknown");
     if (err) {
       g_error_free(err);
     }
@@ -101,20 +94,18 @@ bool SrtNode::create_pipeline()
     return false;
   }
 
-  RCLCPP_INFO(
-    this->get_logger(),
-    "Pipeline parsed and elements retrieved successfully.");
+  RCLCPP_INFO(this->get_logger(),
+              "Pipeline parsed and elements retrieved successfully.");
   return true;
 }
 
 rcl_interfaces::msg::SetParametersResult
-SrtNode::on_parameter_change(const std::vector<rclcpp::Parameter> & parameters)
-{
+SrtNode::on_parameter_change(const std::vector<rclcpp::Parameter> &parameters) {
   rcl_interfaces::msg::SetParametersResult result;
   result.successful = true;
   result.reason = "success";
 
-  for (const auto & param : parameters) {
+  for (const auto &param : parameters) {
     if (param.get_name() == "latency" && srt_sink_) {
       int val = param.as_int();
       g_object_set(srt_sink_, "latency", val, NULL);
@@ -123,24 +114,21 @@ SrtNode::on_parameter_change(const std::vector<rclcpp::Parameter> & parameters)
       int val = param.as_int();
 
       g_object_set(av1_encoder_, "iframeinterval", val, NULL);
-      RCLCPP_INFO(
-        this->get_logger(), "Param Update: IFrame Interval set to %d",
-        val);
+      RCLCPP_INFO(this->get_logger(), "Param Update: IFrame Interval set to %d",
+                  val);
     }
   }
   return result;
 }
 
-void SrtNode::on_bitrate_received(const std_msgs::msg::Int32::SharedPtr msg)
-{
+void SrtNode::on_bitrate_received(const std_msgs::msg::Int32::SharedPtr msg) {
   if (av1_encoder_) {
     g_object_set(av1_encoder_, "bitrate", msg->data, NULL);
     RCLCPP_INFO(this->get_logger(), "Bitrate set to %d", msg->data);
   }
 }
 
-void SrtNode::on_iframe_trigger(const std_msgs::msg::Empty::SharedPtr msg)
-{
+void SrtNode::on_iframe_trigger(const std_msgs::msg::Empty::SharedPtr msg) {
   (void)msg;
   if (av1_encoder_) {
     g_signal_emit_by_name(av1_encoder_, "force-key-unit", NULL);

--- a/src/Cameras/video_streaming/src/srt_node.cpp
+++ b/src/Cameras/video_streaming/src/srt_node.cpp
@@ -1,165 +1,145 @@
 #include "srt_node.hpp"
-#include <rclcpp_components/register_node_macro.hpp>
-#include <glib.h>
-#include "std_msgs/msg/int32.hpp"
 #include "std_msgs/msg/empty.hpp"
+#include "std_msgs/msg/int32.hpp"
+#include <glib.h>
+#include <rclcpp_components/register_node_macro.hpp>
 
-namespace video_streaming 
+namespace video_streaming
 {
 
-SrtNode::SrtNode(const rclcpp::NodeOptions &options)
-  : BaseVideoNode("srt_node", options) 
+SrtNode::SrtNode(const rclcpp::NodeOptions & options) : BaseVideoNode("srt_node", options)
 {
-    RCLCPP_INFO(this->get_logger(), "Initializing SrtNode...");
+  RCLCPP_INFO(this->get_logger(), "Initializing SrtNode...");
 
-    // Start up
-   // latency , iframe_interval
-    this->declare_parameter<std::string>("srt_uri", "srt://127.0.0.1:12345");
-    this->declare_parameter<int>("latency", 100);
-    this->declare_parameter<int>("iframe_interval", 0);
-    
+  // Start up
+  // latency , iframe_interval
+  this->declare_parameter<std::string>("srt_uri", "srt://127.0.0.1:12345");
+  this->declare_parameter<int>("latency", 100);
+  this->declare_parameter<int>("iframe_interval", 0);
 
-    param_callback_handle_ = this->add_on_set_parameters_callback(
-        std::bind(&SrtNode::on_parameter_change, this, std::placeholders::_1));
+  param_callback_handle_ = this->add_on_set_parameters_callback(
+    std::bind(&SrtNode::on_parameter_change, this, std::placeholders::_1));
 
-    bitrate_sub_ = this->create_subscription<std_msgs::msg::Int32>(
-        "~/set_bitrate", 10,
-        std::bind(&SrtNode::on_bitrate_received, this, std::placeholders::_1));
+  bitrate_sub_ = this->create_subscription<std_msgs::msg::Int32>(
+    "~/set_bitrate", 10, std::bind(&SrtNode::on_bitrate_received, this, std::placeholders::_1));
 
-    iframe_sub_ = this->create_subscription<std_msgs::msg::Empty>(
-        "~/trigger_iframe", 10,
-        std::bind(&SrtNode::on_iframe_trigger, this, std::placeholders::_1));
+  iframe_sub_ = this->create_subscription<std_msgs::msg::Empty>(
+    "~/trigger_iframe", 10, std::bind(&SrtNode::on_iframe_trigger, this, std::placeholders::_1));
 
-    /* ==================================================================
-     * TODO: FUTURE FEATURE - SRT STATISTICS
-     * Waiting for Srtstat.msg to be defined in the interfaces package.
-     * ==================================================================
-     */
-    // stats_pub_ = this->create_publisher<video_streaming::msg::Srtstat>("~/srt_stats", 10);
-
-    // params_srv_ = this->create_service<video_streaming::srv::SetStreamingParams>(
-    //     "~/set_params",
-    //     std::bind(&SrtNode::on_set_params, this, std::placeholders::_1, std::placeholders::_2));
-
-    if (!start_pipeline()) {
-        RCLCPP_FATAL(get_logger(), "SrtNode: failed to start pipeline.");
-        throw std::runtime_error("SrtNode: pipeline start failed");
-    }
-    RCLCPP_INFO(get_logger(), "SrtNode constructed and pipeline started.");
+  if (!start_pipeline()) {
+    RCLCPP_FATAL(get_logger(), "SrtNode: failed to start pipeline.");
+    throw std::runtime_error("SrtNode: pipeline start failed");
+  }
+  RCLCPP_INFO(get_logger(), "SrtNode constructed and pipeline started.");
 }
-
 
 bool SrtNode::create_pipeline()
 {
-    std::string srt_uri = this->get_parameter("srt_uri").as_string();
-    int latency_val = this->get_parameter("latency").as_int();
+  std::string srt_uri = this->get_parameter("srt_uri").as_string();
+  int latency_val = this->get_parameter("latency").as_int();
 
+  // ✅ PRODUCTION MODE (NVIDIA Jetson)
+  // Added comma correctly below
+  gchar * desc = g_strdup_printf(
+    "interpipesrc listen-to=detect ! "
+    "nvvidconv ! "
+    "nvv4l2av1enc name=av1_enc ! "
+    "rtpav1pay ! queue ! "
+    "srtsink name=srt_sink uri=%s latency=%d mode=1",
+    srt_uri.c_str(), latency_val);
 
+  /* // [MAC TEST MODE]
     gchar *desc = g_strdup_printf(
-        "interpipesrc listen-to=detect ! "
-        "nvvidconv ! "
-        "nvv4l2av1enc name=av1_enc ! "
-        "rtpav1pay ! queue ! "
-        "srtsink name=srt_sink uri=%s mode=1",
-        srt_uri.c_str()
+        "videotestsrc is-live=true ! video/x-raw,width=640,height=480 ! "
+        "videoconvert ! "
+        "x264enc tune=zerolatency bitrate=2000 speed-preset=ultrafast name=av1_enc ! "
+        "rtph264pay ! queue ! "
+        "srtsink name=srt_sink uri=%s latency=%d mode=1",
+        srt_uri.c_str(),
         latency_val
     );
+    */
 
-    // [MAC TEST MODE]
-    // gchar *desc = g_strdup_printf(
-    //     "videotestsrc is-live=true ! video/x-raw,width=640,height=480 ! "
-    //     "videoconvert ! "
-    //     "x264enc tune=zerolatency bitrate=2000 speed-preset=ultrafast name=av1_enc ! " 
-    //     "rtph264pay ! queue ! "
-    //     "srtsink name=srt_sink uri=%s latency=%d mode=1",
-    //     srt_uri.c_str(),
-    //     latency_val
-    // );
-    
-    RCLCPP_INFO(this->get_logger(), "Using MAC pipeline description: %s", desc);
+  RCLCPP_INFO(this->get_logger(), "Using PRODUCTION pipeline description: %s", desc);
 
-    // same as webrtc_node.cpp
-    GError *err = nullptr;
-    GstElement *p = gst_parse_launch(desc, &err);
-    g_free(desc); 
+  GError * err = nullptr;
+  GstElement * p = gst_parse_launch(desc, &err);
+  g_free(desc);
 
-    if (err || !p) {
-        RCLCPP_ERROR(get_logger(), "gst_parse_launch failed: %s",
-                     err ? err->message : "unknown");
-        if (err) g_error_free(err);
-        return false;
-    }
-    if (!GST_IS_PIPELINE(p)) {
-        RCLCPP_ERROR(get_logger(), "Parsed element is not a pipeline.");
-        gst_object_unref(p);
-        return false;
-    }
-    pipeline_ = p; 
+  if (err || !p) {
+    RCLCPP_ERROR(get_logger(), "gst_parse_launch failed: %s", err ? err->message : "unknown");
+    if (err) g_error_free(err);
+    return false;
+  }
+  if (!GST_IS_PIPELINE(p)) {
+    RCLCPP_ERROR(get_logger(), "Parsed element is not a pipeline.");
+    gst_object_unref(p);
+    return false;
+  }
+  pipeline_ = p;
 
-    av1_encoder_ = this->get_element("av1_enc");
-    srt_sink_ = this->get_element("srt_sink");
+  av1_encoder_ = this->get_element("av1_enc");
+  srt_sink_ = this->get_element("srt_sink");
 
-    if (!av1_encoder_ || !srt_sink_) {
-        RCLCPP_ERROR(get_logger(), "Failed to get elements by name");
-        return false;
-    }
+  if (!av1_encoder_ || !srt_sink_) {
+    RCLCPP_ERROR(get_logger(), "Failed to get elements by name");
+    return false;
+  }
 
-
-    RCLCPP_INFO(this->get_logger(), "Pipeline parsed and elements retrieved successfully.");
-    return true;
-    
+  RCLCPP_INFO(this->get_logger(), "Pipeline parsed and elements retrieved successfully.");
+  return true;
 }
-rcl_interfaces::msg::SetParametersResult SrtNode::on_parameter_change(
-    const std::vector<rclcpp::Parameter> &parameters)
-{
-    rcl_interfaces::msg::SetParametersResult result;
-    result.successful = true;
-    result.reason = "success";
 
-    for (const auto &param : parameters)
-    {
-        if (param.get_name() == "latency" && srt_sink_) {
-            int val = param.as_int();
-            g_object_set(srt_sink_, "latency", val, NULL);
-            RCLCPP_INFO(this->get_logger(), "Param Update: Latency set to %d", val);
-        }
-        else if (param.get_name() == "iframe_interval" && av1_encoder_) {
-            int val = param.as_int();
-            g_object_set(av1_encoder_, "iframeinterval", val, NULL); 
-            RCLCPP_INFO(this->get_logger(), "Param Update: IFrame Interval set to %d (Check encoder property name)", val);
-        }
+rcl_interfaces::msg::SetParametersResult SrtNode::on_parameter_change(
+  const std::vector<rclcpp::Parameter> & parameters)
+{
+  rcl_interfaces::msg::SetParametersResult result;
+  result.successful = true;
+  result.reason = "success";
+
+  for (const auto & param : parameters) {
+    if (param.get_name() == "latency" && srt_sink_) {
+      int val = param.as_int();
+      g_object_set(srt_sink_, "latency", val, NULL);
+      RCLCPP_INFO(this->get_logger(), "Param Update: Latency set to %d", val);
+    } else if (param.get_name() == "iframe_interval" && av1_encoder_) {
+      int val = param.as_int();
+      // ✅ Production property name: iframeinterval
+      g_object_set(av1_encoder_, "iframeinterval", val, NULL);
+      RCLCPP_INFO(this->get_logger(), "Param Update: IFrame Interval set to %d", val);
     }
-    return result;
+  }
+  return result;
 }
 
 void SrtNode::on_bitrate_received(const std_msgs::msg::Int32::SharedPtr msg)
 {
-    if (av1_encoder_) {
-        g_object_set(av1_encoder_, "bitrate", msg->data, NULL);
-        RCLCPP_INFO(this->get_logger(), "Bitrate set to %d", msg->data);
-    }
+  if (av1_encoder_) {
+    g_object_set(av1_encoder_, "bitrate", msg->data, NULL);
+    RCLCPP_INFO(this->get_logger(), "Bitrate set to %d", msg->data);
+  }
 }
 
 void SrtNode::on_iframe_trigger(const std_msgs::msg::Empty::SharedPtr msg)
 {
-    (void)msg;
-    if (av1_encoder_) {
-        // nvv4l2av1enc  'force-key-unit' )
-        g_signal_emit_by_name(av1_encoder_, "force-key-unit", NULL);
-        RCLCPP_INFO(this->get_logger(), "I-Frame triggered");
-    }
+  (void)msg;
+  if (av1_encoder_) {
+    g_signal_emit_by_name(av1_encoder_, "force-key-unit", NULL);
+    RCLCPP_INFO(this->get_logger(), "I-Frame triggered");
+  }
 }
 
 /* ==================================================================================
-     * TODO: FUTURE FEATURE - SRT STATISTICS & SERVICE
-     * * The following code implements SRT statistics publishing and a custom service.
-     * Per feedback, we are currently pausing this functionality to focus on the video 
-     * pipeline and using ROS 2 Parameters for control.
-     * * Once custom .msg and .srv files are added to the interfaces package, 
-     * uncomment this block and the corresponding headers.
-     * ==================================================================================
-     */
+ * TODO: FUTURE FEATURE - SRT STATISTICS & SERVICE
+ * * The following code implements SRT statistics publishing and a custom service.
+ * * Per feedback, we are currently pausing this functionality to focus on the video
+ * * pipeline and using ROS 2 Parameters for control.
+ * * Once custom .msg and .srv files are added to the interfaces package,
+ * * uncomment this block and the corresponding headers.
+ * ==================================================================================
+ */
 
+/*
 // void SrtNode::on_srt_stats(GstElement * element, GstStructure * stats, gpointer user_data)
 // {
 //     SrtNode* node = static_cast<SrtNode*>(user_data);
@@ -220,7 +200,8 @@ void SrtNode::on_iframe_trigger(const std_msgs::msg::Empty::SharedPtr msg)
 
 //     node->stats_pub_->publish(stats_msg);
 // }
+*/
+
 }  // namespace video_streaming
-  
 
 RCLCPP_COMPONENTS_REGISTER_NODE(video_streaming::SrtNode)

--- a/src/Cameras/video_streaming/src/srt_node.cpp
+++ b/src/Cameras/video_streaming/src/srt_node.cpp
@@ -4,10 +4,12 @@
 #include <glib.h>
 #include <rclcpp_components/register_node_macro.hpp>
 
-namespace video_streaming {
+namespace video_streaming
+{
 
-SrtNode::SrtNode(const rclcpp::NodeOptions &options)
-    : BaseVideoNode("srt_node", options) {
+SrtNode::SrtNode(const rclcpp::NodeOptions & options)
+: BaseVideoNode("srt_node", options)
+{
   RCLCPP_INFO(this->get_logger(), "Initializing SrtNode...");
 
   // Start up
@@ -18,15 +20,15 @@ SrtNode::SrtNode(const rclcpp::NodeOptions &options)
   this->declare_parameter<bool>("test_mode", false);
 
   param_callback_handle_ = this->add_on_set_parameters_callback(
-      std::bind(&SrtNode::on_parameter_change, this, std::placeholders::_1));
+    std::bind(&SrtNode::on_parameter_change, this, std::placeholders::_1));
 
   bitrate_sub_ = this->create_subscription<std_msgs::msg::Int32>(
-      "~/set_bitrate", 10,
-      std::bind(&SrtNode::on_bitrate_received, this, std::placeholders::_1));
+    "~/set_bitrate", 10,
+    std::bind(&SrtNode::on_bitrate_received, this, std::placeholders::_1));
 
   iframe_sub_ = this->create_subscription<std_msgs::msg::Empty>(
-      "~/trigger_iframe", 10,
-      std::bind(&SrtNode::on_iframe_trigger, this, std::placeholders::_1));
+    "~/trigger_iframe", 10,
+    std::bind(&SrtNode::on_iframe_trigger, this, std::placeholders::_1));
 
   if (!start_pipeline()) {
     RCLCPP_FATAL(get_logger(), "SrtNode: failed to start pipeline.");
@@ -35,47 +37,53 @@ SrtNode::SrtNode(const rclcpp::NodeOptions &options)
   RCLCPP_INFO(get_logger(), "SrtNode constructed and pipeline started.");
 }
 
-bool SrtNode::create_pipeline() {
+bool SrtNode::create_pipeline()
+{
   std::string srt_uri = this->get_parameter("srt_uri").as_string();
   int latency_val = this->get_parameter("latency").as_int();
 
   bool test_mode = this->get_parameter("test_mode").as_bool();
 
-  gchar *desc;
+  gchar * desc;
 
   if (test_mode) {
     desc = g_strdup_printf(
-        "videotestsrc is-live=true ! video/x-raw,width=640,height=480 ! "
-        "videoconvert ! "
-        "x264enc tune=zerolatency bitrate=2000 speed-preset=ultrafast "
-        "name=av1_enc ! "
-        "rtph264pay ! queue ! "
-        "srtsink name=srt_sink uri=%s latency=%d mode=1",
-        srt_uri.c_str(), latency_val);
-    RCLCPP_WARN(this->get_logger(), "Using MAC TEST pipeline description: %s",
-                desc);
+      "videotestsrc is-live=true ! video/x-raw,width=640,height=480 ! "
+      "videoconvert ! "
+      "x264enc tune=zerolatency bitrate=2000 speed-preset=ultrafast "
+      "name=av1_enc ! "
+      "rtph264pay ! queue ! "
+      "srtsink name=srt_sink uri=%s latency=%d mode=1",
+      srt_uri.c_str(), latency_val);
+    RCLCPP_WARN(
+      this->get_logger(), "Using MAC TEST pipeline description: %s",
+      desc);
 
   } else {
-    desc = g_strdup_printf("interpipesrc listen-to=detect ! "
-                           "nvvidconv ! "
-                           "nvv4l2av1enc name=av1_enc ! "
-                           "rtpav1pay ! queue ! "
-                           "srtsink name=srt_sink uri=%s latency=%d mode=1",
-                           srt_uri.c_str(), latency_val);
-    RCLCPP_INFO(this->get_logger(), "Using PRODUCTION pipeline description: %s",
-                desc);
+    desc = g_strdup_printf(
+      "interpipesrc listen-to=detect ! "
+      "nvvidconv ! "
+      "nvv4l2av1enc name=av1_enc ! "
+      "rtpav1pay ! queue ! "
+      "srtsink name=srt_sink uri=%s latency=%d mode=1",
+      srt_uri.c_str(), latency_val);
+    RCLCPP_INFO(
+      this->get_logger(), "Using PRODUCTION pipeline description: %s",
+      desc);
   }
   RCLCPP_INFO(this->get_logger(), "Pipeline description: %s", desc);
 
-  GError *err = nullptr;
-  GstElement *p = gst_parse_launch(desc, &err);
+  GError * err = nullptr;
+  GstElement * p = gst_parse_launch(desc, &err);
   g_free(desc);
 
   if (err || !p) {
-    RCLCPP_ERROR(get_logger(), "gst_parse_launch failed: %s",
-                 err ? err->message : "unknown");
-    if (err)
+    RCLCPP_ERROR(
+      get_logger(), "gst_parse_launch failed: %s",
+      err ? err->message : "unknown");
+    if (err) {
       g_error_free(err);
+    }
     return false;
   }
   if (!GST_IS_PIPELINE(p)) {
@@ -93,18 +101,20 @@ bool SrtNode::create_pipeline() {
     return false;
   }
 
-  RCLCPP_INFO(this->get_logger(),
-              "Pipeline parsed and elements retrieved successfully.");
+  RCLCPP_INFO(
+    this->get_logger(),
+    "Pipeline parsed and elements retrieved successfully.");
   return true;
 }
 
 rcl_interfaces::msg::SetParametersResult
-SrtNode::on_parameter_change(const std::vector<rclcpp::Parameter> &parameters) {
+SrtNode::on_parameter_change(const std::vector<rclcpp::Parameter> & parameters)
+{
   rcl_interfaces::msg::SetParametersResult result;
   result.successful = true;
   result.reason = "success";
 
-  for (const auto &param : parameters) {
+  for (const auto & param : parameters) {
     if (param.get_name() == "latency" && srt_sink_) {
       int val = param.as_int();
       g_object_set(srt_sink_, "latency", val, NULL);
@@ -113,21 +123,24 @@ SrtNode::on_parameter_change(const std::vector<rclcpp::Parameter> &parameters) {
       int val = param.as_int();
 
       g_object_set(av1_encoder_, "iframeinterval", val, NULL);
-      RCLCPP_INFO(this->get_logger(), "Param Update: IFrame Interval set to %d",
-                  val);
+      RCLCPP_INFO(
+        this->get_logger(), "Param Update: IFrame Interval set to %d",
+        val);
     }
   }
   return result;
 }
 
-void SrtNode::on_bitrate_received(const std_msgs::msg::Int32::SharedPtr msg) {
+void SrtNode::on_bitrate_received(const std_msgs::msg::Int32::SharedPtr msg)
+{
   if (av1_encoder_) {
     g_object_set(av1_encoder_, "bitrate", msg->data, NULL);
     RCLCPP_INFO(this->get_logger(), "Bitrate set to %d", msg->data);
   }
 }
 
-void SrtNode::on_iframe_trigger(const std_msgs::msg::Empty::SharedPtr msg) {
+void SrtNode::on_iframe_trigger(const std_msgs::msg::Empty::SharedPtr msg)
+{
   (void)msg;
   if (av1_encoder_) {
     g_signal_emit_by_name(av1_encoder_, "force-key-unit", NULL);

--- a/src/Cameras/video_streaming/src/srt_node.cpp
+++ b/src/Cameras/video_streaming/src/srt_node.cpp
@@ -1,0 +1,226 @@
+#include "srt_node.hpp"
+#include <rclcpp_components/register_node_macro.hpp>
+#include <glib.h>
+#include "std_msgs/msg/int32.hpp"
+#include "std_msgs/msg/empty.hpp"
+
+namespace video_streaming 
+{
+
+SrtNode::SrtNode(const rclcpp::NodeOptions &options)
+  : BaseVideoNode("srt_node", options) 
+{
+    RCLCPP_INFO(this->get_logger(), "Initializing SrtNode...");
+
+    // Start up
+   // latency , iframe_interval
+    this->declare_parameter<std::string>("srt_uri", "srt://127.0.0.1:12345");
+    this->declare_parameter<int>("latency", 100);
+    this->declare_parameter<int>("iframe_interval", 0);
+    
+
+    param_callback_handle_ = this->add_on_set_parameters_callback(
+        std::bind(&SrtNode::on_parameter_change, this, std::placeholders::_1));
+
+    bitrate_sub_ = this->create_subscription<std_msgs::msg::Int32>(
+        "~/set_bitrate", 10,
+        std::bind(&SrtNode::on_bitrate_received, this, std::placeholders::_1));
+
+    iframe_sub_ = this->create_subscription<std_msgs::msg::Empty>(
+        "~/trigger_iframe", 10,
+        std::bind(&SrtNode::on_iframe_trigger, this, std::placeholders::_1));
+
+    /* ==================================================================
+     * TODO: FUTURE FEATURE - SRT STATISTICS
+     * Waiting for Srtstat.msg to be defined in the interfaces package.
+     * ==================================================================
+     */
+    // stats_pub_ = this->create_publisher<video_streaming::msg::Srtstat>("~/srt_stats", 10);
+
+    // params_srv_ = this->create_service<video_streaming::srv::SetStreamingParams>(
+    //     "~/set_params",
+    //     std::bind(&SrtNode::on_set_params, this, std::placeholders::_1, std::placeholders::_2));
+
+    if (!start_pipeline()) {
+        RCLCPP_FATAL(get_logger(), "SrtNode: failed to start pipeline.");
+        throw std::runtime_error("SrtNode: pipeline start failed");
+    }
+    RCLCPP_INFO(get_logger(), "SrtNode constructed and pipeline started.");
+}
+
+
+bool SrtNode::create_pipeline()
+{
+    std::string srt_uri = this->get_parameter("srt_uri").as_string();
+    int latency_val = this->get_parameter("latency").as_int();
+
+
+    gchar *desc = g_strdup_printf(
+        "interpipesrc listen-to=detect ! "
+        "nvvidconv ! "
+        "nvv4l2av1enc name=av1_enc ! "
+        "rtpav1pay ! queue ! "
+        "srtsink name=srt_sink uri=%s mode=1",
+        srt_uri.c_str()
+        latency_val
+    );
+
+    // [MAC TEST MODE]
+    // gchar *desc = g_strdup_printf(
+    //     "videotestsrc is-live=true ! video/x-raw,width=640,height=480 ! "
+    //     "videoconvert ! "
+    //     "x264enc tune=zerolatency bitrate=2000 speed-preset=ultrafast name=av1_enc ! " 
+    //     "rtph264pay ! queue ! "
+    //     "srtsink name=srt_sink uri=%s latency=%d mode=1",
+    //     srt_uri.c_str(),
+    //     latency_val
+    // );
+    
+    RCLCPP_INFO(this->get_logger(), "Using MAC pipeline description: %s", desc);
+
+    // same as webrtc_node.cpp
+    GError *err = nullptr;
+    GstElement *p = gst_parse_launch(desc, &err);
+    g_free(desc); 
+
+    if (err || !p) {
+        RCLCPP_ERROR(get_logger(), "gst_parse_launch failed: %s",
+                     err ? err->message : "unknown");
+        if (err) g_error_free(err);
+        return false;
+    }
+    if (!GST_IS_PIPELINE(p)) {
+        RCLCPP_ERROR(get_logger(), "Parsed element is not a pipeline.");
+        gst_object_unref(p);
+        return false;
+    }
+    pipeline_ = p; 
+
+    av1_encoder_ = this->get_element("av1_enc");
+    srt_sink_ = this->get_element("srt_sink");
+
+    if (!av1_encoder_ || !srt_sink_) {
+        RCLCPP_ERROR(get_logger(), "Failed to get elements by name");
+        return false;
+    }
+
+
+    RCLCPP_INFO(this->get_logger(), "Pipeline parsed and elements retrieved successfully.");
+    return true;
+    
+}
+rcl_interfaces::msg::SetParametersResult SrtNode::on_parameter_change(
+    const std::vector<rclcpp::Parameter> &parameters)
+{
+    rcl_interfaces::msg::SetParametersResult result;
+    result.successful = true;
+    result.reason = "success";
+
+    for (const auto &param : parameters)
+    {
+        if (param.get_name() == "latency" && srt_sink_) {
+            int val = param.as_int();
+            g_object_set(srt_sink_, "latency", val, NULL);
+            RCLCPP_INFO(this->get_logger(), "Param Update: Latency set to %d", val);
+        }
+        else if (param.get_name() == "iframe_interval" && av1_encoder_) {
+            int val = param.as_int();
+            g_object_set(av1_encoder_, "iframeinterval", val, NULL); 
+            RCLCPP_INFO(this->get_logger(), "Param Update: IFrame Interval set to %d (Check encoder property name)", val);
+        }
+    }
+    return result;
+}
+
+void SrtNode::on_bitrate_received(const std_msgs::msg::Int32::SharedPtr msg)
+{
+    if (av1_encoder_) {
+        g_object_set(av1_encoder_, "bitrate", msg->data, NULL);
+        RCLCPP_INFO(this->get_logger(), "Bitrate set to %d", msg->data);
+    }
+}
+
+void SrtNode::on_iframe_trigger(const std_msgs::msg::Empty::SharedPtr msg)
+{
+    (void)msg;
+    if (av1_encoder_) {
+        // nvv4l2av1enc  'force-key-unit' )
+        g_signal_emit_by_name(av1_encoder_, "force-key-unit", NULL);
+        RCLCPP_INFO(this->get_logger(), "I-Frame triggered");
+    }
+}
+
+/* ==================================================================================
+     * TODO: FUTURE FEATURE - SRT STATISTICS & SERVICE
+     * * The following code implements SRT statistics publishing and a custom service.
+     * Per feedback, we are currently pausing this functionality to focus on the video 
+     * pipeline and using ROS 2 Parameters for control.
+     * * Once custom .msg and .srv files are added to the interfaces package, 
+     * uncomment this block and the corresponding headers.
+     * ==================================================================================
+     */
+
+// void SrtNode::on_srt_stats(GstElement * element, GstStructure * stats, gpointer user_data)
+// {
+//     SrtNode* node = static_cast<SrtNode*>(user_data);
+//     if (!node) return;
+
+//     video_streaming::msg::Srtstat stats_msg;
+//     if (!stats) {
+//         RCLCPP_WARN(node->get_logger(), "on_srt_stats called with null GstStructure");
+//         node->stats_pub_->publish(stats_msg);
+//         return;
+//     }
+
+//     // Debug: print the full structure to discover actual key names & units
+//     gchar *s = gst_structure_to_string(stats);
+//     RCLCPP_DEBUG(node->get_logger(), "SRT stats structure: %s", s);
+//     g_free(s);
+
+//     // rtt -> Srtstat.rtt (seconds)
+//     double rtt_double = 0.0;
+//     gint rtt_int = 0;
+//     if (gst_structure_get_double(stats, "rtt", &rtt_double)) {
+//         // assume already in seconds
+//         stats_msg.rtt = rtt_double;
+//     } else if (gst_structure_get_int(stats, "rtt", &rtt_int)) {
+//         // some sources report ms as integer — convert to seconds
+//         stats_msg.rtt = static_cast<double>(rtt_int) / 1000.0;
+//     }
+
+//     // bandwidth -> Srtstat.bandwidth (bits/sec)
+//     double bw_double = 0.0;
+//     gint bw_int = 0;
+//     if (gst_structure_get_double(stats, "bandwidth", &bw_double)) {
+//         stats_msg.bandwidth = bw_double;
+//     } else if (gst_structure_get_int(stats, "bandwidth", &bw_int)) {
+//         stats_msg.bandwidth = static_cast<double>(bw_int);
+//     }
+
+//     // packets_sent -> Srtstat.packets_sent
+//     gint packets_sent = 0;
+//     if (gst_structure_get_int(stats, "packets-sent", &packets_sent) ||
+//         gst_structure_get_int(stats, "packets_sent", &packets_sent)) {
+//         stats_msg.packets_sent = static_cast<int64_t>(packets_sent);
+//     }
+
+//     // packets_lost -> Srtstat.packets_lost
+//     gint packets_lost = 0;
+//     if (gst_structure_get_int(stats, "packets-lost", &packets_lost) ||
+//         gst_structure_get_int(stats, "packets_lost", &packets_lost)) {
+//         stats_msg.packets_lost = static_cast<int64_t>(packets_lost);
+//     }
+
+//     // packets_retransmitted -> Srtstat.packets_retransmitted
+//     gint packets_retx = 0;
+//     if (gst_structure_get_int(stats, "packets-retransmitted", &packets_retx) ||
+//         gst_structure_get_int(stats, "packets_retransmitted", &packets_retx)) {
+//         stats_msg.packets_retransmitted = static_cast<int64_t>(packets_retx);
+//     }
+
+//     node->stats_pub_->publish(stats_msg);
+// }
+}  // namespace video_streaming
+  
+
+RCLCPP_COMPONENTS_REGISTER_NODE(video_streaming::SrtNode)

--- a/src/Cameras/video_streaming/src/srt_node.cpp
+++ b/src/Cameras/video_streaming/src/srt_node.cpp
@@ -39,36 +39,37 @@ bool SrtNode::create_pipeline() {
   int latency_val = this->get_parameter("latency").as_int();
 
   bool test_mode = false;
-  try{
+  try {
     test_mode = this->get_parameter("test_mode").as_bool();
-  } catch(...) {
+  } catch (...) {
     test_mode = this->declare_parameter<bool>("test_mode", false);
   }
 
   gchar *desc;
 
-  if(test_mode){
-    desc = g_strdup_printf("videotestsrc is-live=true ! video/x-raw,width=640,height=480 ! "
-                           "videoconvert ! "
-                           "x264enc tune=zerolatency bitrate=2000 speed-preset=ultrafast name=av1_enc ! "
-                           "rtph264pay ! queue ! "
-                           "srtsink name=srt_sink uri=%s latency=%d mode=1",
-                           srt_uri.c_str(), latency_val);
-    RCLCPP_WARN(this->get_logger(), "Using MAC TEST pipeline description: %s", desc);
+  if (test_mode) {
+    desc = g_strdup_printf(
+        "videotestsrc is-live=true ! video/x-raw,width=640,height=480 ! "
+        "videoconvert ! "
+        "x264enc tune=zerolatency bitrate=2000 speed-preset=ultrafast "
+        "name=av1_enc ! "
+        "rtph264pay ! queue ! "
+        "srtsink name=srt_sink uri=%s latency=%d mode=1",
+        srt_uri.c_str(), latency_val);
+    RCLCPP_WARN(this->get_logger(), "Using MAC TEST pipeline description: %s",
+                desc);
 
   } else {
     desc = g_strdup_printf("interpipesrc listen-to=detect ! "
                            "nvvidconv ! "
                            "nvv4l2av1enc name=av1_enc ! "
                            "rtpav1pay ! queue ! "
-                      "srtsink name=srt_sink uri=%s latency=%d mode=1",
-                      srt_uri.c_str(), latency_val);
+                           "srtsink name=srt_sink uri=%s latency=%d mode=1",
+                           srt_uri.c_str(), latency_val);
     RCLCPP_INFO(this->get_logger(), "Using PRODUCTION pipeline description: %s",
-                 desc);
-    }
-    RCLCPP_INFO(this->get_logger(), "Pipeline description: %s",
                 desc);
-
+  }
+  RCLCPP_INFO(this->get_logger(), "Pipeline description: %s", desc);
 
   GError *err = nullptr;
   GstElement *p = gst_parse_launch(desc, &err);


### PR DESCRIPTION
This PR implements the SrtNode for video streaming using GStreamer. 

**Key Changes**

1. Registered SrtNode as a component using RCLCPP_COMPONENTS_REGISTER_NODE.
Updated CMakeLists.txt to build a shared library instead of an executable.

2. Removed Custom Interfaces: Deleted Srtstat.msg and SetStreamingParams.srv to avoid creating new interface definitions.
ROS 2 Parameters: Implemented on_parameter_change callback.

3. Cleaned up package.xml and CMakeLists.txt (removed rosidl generation and unused dependencies).
    Updated video_streaming.launch.py to load video_streaming::SrtNode into the composable node container.
    Fixed build dependencies for input_node (restored interfaces package link).

Notes
Implemented a new test_mode parameter to support local development.
Updated the default SRT port from 12345 to 7001 (standard convention) in both the C++ node and launch file.


