### PR TITLE
Mount udev rules into container

### DIFF
--- a/.devcontainer/jetson/devcontainer.json
+++ b/.devcontainer/jetson/devcontainer.json
@@ -8,6 +8,7 @@
     "--privileged",
     "--volume=/dev/v4l/by-id:/dev/v4l/by-id",
     "--volume=/dev/serial/by-id:/dev/serial/by-id",
+    "--volume=/etc/udev/rules.d:/etc/udev/rules.d:ro",
     "--volume=/sys:/sys",
     "--volume=/etc/timezone:/etc/timezone",
     "--volume=/tmp/argus_socket:/tmp/argus_socket",


### PR DESCRIPTION
the ZED node was failing to launch. I found that mounting the udev rules fixed the issue. I tested by only launch `ros2 launch navigation zed.launch.py`. I tried mounting vs not mounting udev rules, and also made sure to rebuild the container and even reboot a few times on both versions. 

