### PR TITLE
feat: gradient filter

### DIFF
--- a/src/Nav/cprt_gridmap_filters/CMakeLists.txt
+++ b/src/Nav/cprt_gridmap_filters/CMakeLists.txt
@@ -42,6 +42,7 @@ set(dependencies
 
 set(filter_libs
   preserve_cost_inflation_filter
+  gradient_filter
 )
 
 ###########
@@ -58,6 +59,7 @@ include_directories(
 
 ## Declare cpp libraries
 add_library(preserve_cost_inflation_filter SHARED src/PreserveCostInflationFilter.cpp)
+add_library(gradient_filter SHARED src/GradientFilter.cpp)
 
 foreach(lib_name ${filter_libs})
   ament_target_dependencies(${lib_name} SYSTEM

--- a/src/Nav/cprt_gridmap_filters/filter_plugins.xml
+++ b/src/Nav/cprt_gridmap_filters/filter_plugins.xml
@@ -7,4 +7,11 @@
       </description>
     </class>
   </library>
+  <library path="gradient_filter">
+    <class name="cprtGridMapFilters/GradientFilter" type="grid_map::GradientFilter" base_class_type="filters::FilterBase&lt;grid_map::GridMap&gt;">
+      <description>
+        Computes the gradient of a specified layer in the grid map
+      </description>
+    </class>
+  </library>
 </class_libraries>

--- a/src/Nav/cprt_gridmap_filters/include/GradientFilter.hpp
+++ b/src/Nav/cprt_gridmap_filters/include/GradientFilter.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <Eigen/Core>
+#include <filters/filter_base.hpp>
+#include <grid_map_core/grid_map_core.hpp>
+#include <grid_map_cv/utilities.hpp>
+
+namespace grid_map {
+
+class GradientFilter : public filters::FilterBase<grid_map::GridMap> {
+public:
+  GradientFilter() = default;
+  virtual ~GradientFilter() = default;
+  bool configure() override;
+  bool update(const grid_map::GridMap &map_in,
+              grid_map::GridMap &map_out) override;
+  enum class Stencil { CentralDifference, Sobel };
+  enum class Mode { Magnitude, Squared };
+
+private:
+  std::string input_layer_ = "elevation";
+  std::string output_layer_ = "gradient_mag";
+
+  // "mag" -> sqrt(dzdx^2 + dzdy^2), "sq" -> dzdx^2 + dzdy^2
+  Mode mode_ = Mode::Magnitude;
+
+  // "central" uses (x+1 - x-1)/(2*res), "sobel" uses 3x3 sobel stencil
+  Stencil stencil_ = Stencil::CentralDifference;
+
+  // If true, will attempt one-sided differences at edges if possible.
+  bool allow_one_sided_edges_ = true;
+
+  static constexpr const char *FilterName = "GradientFilter";
+
+  template <typename T>
+  bool readParam(grid_map::ParameterReader &param_reader,
+                 const std::string &param_name, T &output) {
+    if (!param_reader.get(param_name, output)) {
+      RCLCPP_ERROR(this->logging_interface_->get_logger(),
+                   "%s did not find parameter '%s'.", FilterName,
+                   param_name.c_str());
+      return false;
+    }
+    return true;
+  }
+};
+
+} // namespace grid_map

--- a/src/Nav/cprt_gridmap_filters/src/GradientFilter.cpp
+++ b/src/Nav/cprt_gridmap_filters/src/GradientFilter.cpp
@@ -1,0 +1,194 @@
+#include "GradientFilter.hpp"
+
+#include <cmath>
+#include <limits>
+#include <pluginlib/class_list_macros.hpp>
+
+namespace grid_map {
+
+static inline bool isFinite(float value) { return std::isfinite(value); }
+static inline float quietNaN() {
+  return std::numeric_limits<float>::quiet_NaN();
+}
+
+bool GradientFilter::configure() {
+  grid_map::ParameterReader param_reader(this->param_prefix_,
+                                         this->params_interface_);
+  if (!readParam<std::string>(param_reader, "input_layer", input_layer_)) {
+    return false;
+  }
+  if (!readParam<std::string>(param_reader, "output_layer", output_layer_)) {
+    return false;
+  }
+  std::string stencil_str;
+  if (!readParam<std::string>(param_reader, "stencil", stencil_str)) {
+    return false;
+  }
+  if (stencil_str == "central" || stencil_str == "cen") {
+    stencil_ = Stencil::CentralDifference;
+  } else if (stencil_str == "sob" || stencil_str == "sobel") {
+    stencil_ = Stencil::Sobel;
+  } else {
+    RCLCPP_ERROR(this->logging_interface_->get_logger(),
+                 "%s parameter 'stencil' has invalid value '%s'. Options are: "
+                 "central (cen) or sobel (sob).",
+                 FilterName, stencil_str.c_str());
+    return false;
+  }
+
+  std::string mode_str;
+  if (!readParam<std::string>(param_reader, "mode", mode_str)) {
+    return false;
+  }
+  if (mode_str == "mag" || mode_str == "magnitude") {
+    mode_ = Mode::Magnitude;
+  } else if (mode_str == "sq" || mode_str == "squared") {
+    mode_ = Mode::Squared;
+  } else {
+    RCLCPP_ERROR(this->logging_interface_->get_logger(),
+                 "%s parameter 'mode' has invalid value '%s'. Options are: "
+                 "magnitude (mag) or squared (sq).",
+                 FilterName, mode_str.c_str());
+    return false;
+  }
+  if (!readParam<bool>(param_reader, "allow_one_sided_edges",
+                       allow_one_sided_edges_)) {
+    return false;
+  }
+  return true;
+}
+
+static inline bool in_bounds(int row, int col, int num_rows, int num_cols) {
+  return (row >= 0 && row < num_rows && col >= 0 && col < num_cols);
+}
+
+bool GradientFilter::update(const grid_map::GridMap &map_in,
+                            grid_map::GridMap &map_out) {
+  map_out = map_in;
+  if (!map_out.exists(output_layer_)) {
+    map_out.add(output_layer_);
+  }
+
+  const auto &height_layer = map_in[input_layer_];
+  auto &gradient_layer = map_out[output_layer_];
+
+  const int num_rows = height_layer.rows();
+  const int num_cols = height_layer.cols();
+  const float cell_size_m = static_cast<float>(map_in.getResolution());
+
+  for (int row = 0; row < num_rows; ++row) {
+    for (int col = 0; col < num_cols; ++col) {
+
+      const float center_height = height_layer(row, col);
+      if (!isFinite(center_height)) {
+        gradient_layer(row, col) = quietNaN();
+        continue;
+      }
+
+      float dHeight_dx = quietNaN();
+      float dHeight_dy = quietNaN();
+
+      if (stencil_ == Stencil::CentralDifference) {
+        // ---- central difference ----
+        const int col_left = col - 1;
+        const int col_right = col + 1;
+        const int row_up = row - 1;
+        const int row_down = row + 1;
+
+        const bool has_left = in_bounds(row, col_left, num_rows, num_cols) &&
+                              isFinite(height_layer(row, col_left));
+        const bool has_right = in_bounds(row, col_right, num_rows, num_cols) &&
+                               isFinite(height_layer(row, col_right));
+        const bool has_up = in_bounds(row_up, col, num_rows, num_cols) &&
+                            isFinite(height_layer(row_up, col));
+        const bool has_down = in_bounds(row_down, col, num_rows, num_cols) &&
+                              isFinite(height_layer(row_down, col));
+
+        // x derivative
+        if (has_left && has_right) {
+          dHeight_dx =
+              (height_layer(row, col_right) - height_layer(row, col_left)) /
+              (2.0f * cell_size_m);
+        } else if (allow_one_sided_edges_) {
+          if (has_right) {
+            dHeight_dx =
+                (height_layer(row, col_right) - center_height) / cell_size_m;
+          } else if (has_left) {
+            dHeight_dx =
+                (center_height - height_layer(row, col_left)) / cell_size_m;
+          }
+        }
+
+        // y derivative
+        if (has_up && has_down) {
+          dHeight_dy =
+              (height_layer(row_down, col) - height_layer(row_up, col)) /
+              (2.0f * cell_size_m);
+        } else if (allow_one_sided_edges_) {
+          if (has_down) {
+            dHeight_dy =
+                (height_layer(row_down, col) - center_height) / cell_size_m;
+          } else if (has_up) {
+            dHeight_dy =
+                (center_height - height_layer(row_up, col)) / cell_size_m;
+          }
+        }
+
+      } else {
+        // ---- 3x3 Sobel ----
+        // Only valid for interior cells
+        const bool is_border_cell = (row == 0 || row == num_rows - 1 ||
+                                     col == 0 || col == num_cols - 1);
+        if (is_border_cell) {
+          gradient_layer(row, col) = quietNaN();
+          continue;
+        }
+
+        const float h_ul = height_layer(row - 1, col - 1);
+        const float h_uc = height_layer(row - 1, col);
+        const float h_ur = height_layer(row - 1, col + 1);
+        const float h_ml = height_layer(row, col - 1);
+        const float h_mr = height_layer(row, col + 1);
+        const float h_ll = height_layer(row + 1, col - 1);
+        const float h_lc = height_layer(row + 1, col);
+        const float h_lr = height_layer(row + 1, col + 1);
+
+        const bool all_neighbors_finite =
+            (isFinite(h_ul) && isFinite(h_uc) && isFinite(h_ur) &&
+             isFinite(h_ml) && isFinite(h_mr) && isFinite(h_ll) &&
+             isFinite(h_lc) && isFinite(h_lr));
+
+        if (!all_neighbors_finite) {
+          gradient_layer(row, col) = quietNaN();
+          continue;
+        }
+
+        const float sobel_gx = (-1.f * h_ul + 1.f * h_ur) +
+                               (-2.f * h_ml + 2.f * h_mr) +
+                               (-1.f * h_ll + 1.f * h_lr);
+
+        const float sobel_gy = (-1.f * h_ul - 2.f * h_uc - 1.f * h_ur) +
+                               (1.f * h_ll + 2.f * h_lc + 1.f * h_lr);
+
+        dHeight_dx = sobel_gx / (8.0f * cell_size_m);
+        dHeight_dy = sobel_gy / (8.0f * cell_size_m);
+      }
+
+      if (!isFinite(dHeight_dx) || !isFinite(dHeight_dy)) {
+        gradient_layer(row, col) = quietNaN();
+        continue;
+      }
+
+      const float grad_sq = dHeight_dx * dHeight_dx + dHeight_dy * dHeight_dy;
+      gradient_layer(row, col) =
+          (mode_ == Mode::Squared) ? grad_sq : std::sqrt(grad_sq);
+    }
+  }
+
+  return true;
+}
+
+} // namespace grid_map
+
+PLUGINLIB_EXPORT_CLASS(grid_map::GradientFilter,
+                       filters::FilterBase<grid_map::GridMap>)

--- a/src/Nav/cprt_gridmap_filters/src/PreserveCostInflationFilter.cpp
+++ b/src/Nav/cprt_gridmap_filters/src/PreserveCostInflationFilter.cpp
@@ -148,8 +148,7 @@ void PreserveCostInflationFilter<T>::computeWithSimpleSerialMethod(
 
     const grid_map::Index index = *iterator;
     grid_map::Position position;
-    mapIn.getPosition(
-        index, position); // Get position of cell from grid_map::Index of cell
+    mapIn.getPosition(index, position);
 
     const float value = layerIn.coeff(index(0), index(1));
     if (!std::isfinite(value)) {

--- a/src/Nav/navigation/config/elevation_mapping/postprocessing_traversability.yaml
+++ b/src/Nav/navigation/config/elevation_mapping/postprocessing_traversability.yaml
@@ -48,25 +48,18 @@ elevation_mapping:
 
       # Compute Surface normals
       filter4:
-        name: surface_normals
-        type: gridMapFilters/NormalVectorsFilter
+        name: slope_gradient
+        type: cprtGridMapFilters/GradientFilter
         params:
-          # input_layer: elevation_inpainted
           input_layer: elevation_smooth
-          output_layers_prefix: normal_vectors_
-          radius: 0.35 # 1.5 times the map resolution is good
-          normal_vector_positive_axis: z
-
-      # Compute slope from surface normal.
-      filter5:
-        name: slope
-        type: gridMapFilters/MathExpressionFilter
-        params:
           output_layer: slope
-          expression: acos(normal_vectors_z)
+          mode: magnitude
+          stencil: sobel
+          allow_one_sided_edges: true
+
 
       # Compute roughness as absolute difference from map to smoothened map.
-      filter6:
+      filter5:
         name: roughness
         type: gridMapFilters/MathExpressionFilter
         params:
@@ -74,7 +67,7 @@ elevation_mapping:
           expression: abs(elevation - elevation_smooth)
 
       # Compute traversability as normalized weighted sum of slope and roughness.
-      filter7:
+      filter6:
         name: traversability
         type: gridMapFilters/MathExpressionFilter
         params:
@@ -82,7 +75,7 @@ elevation_mapping:
           expression: 0.13 * (slope / 0.6) + 0.24 * (roughness / 0.1) # roughness: 0.3
 
       # Set lower threshold on traversability.
-      filter8:
+      filter7:
         name: traversability_lower_threshold
         type: gridMapFilters/ThresholdFilter
         params:
@@ -92,7 +85,7 @@ elevation_mapping:
           set_to: 0.0
 
       # Set upper threshold on traversability.
-      filter9:
+      filter8:
         name: traversability_upper_threshold
         type: gridMapFilters/ThresholdFilter
         params:
@@ -102,7 +95,7 @@ elevation_mapping:
           set_to: 1.0 # Other uses: .nan, .inf
 
       # Inflate the traversability map to account for the robot's footprint.
-      filter10:
+      filter9:
         name: preserve_cost_inflation_filter
         type: cprtGridMapFilters/PreserveCostInflationFilter
         params:
@@ -112,8 +105,8 @@ elevation_mapping:
           decay_inflation_radius: 0.8 # in m
           decay_rate: 1.2 # See script at /src/cprt_grid_map_filters/scripts/calculate_decay_rate.py to help calculate.
       
-      filter11:
+      filter10:
         name: delete_unnecessary_layers
         type: gridMapFilters/DeletionFilter
         params:
-          layers: [roughness, slope, normal_vectors_x, normal_vectors_y, normal_vectors_z] # List of layers.
+          layers: [roughness, slope,] # List of layers.


### PR DESCRIPTION
This filter offers 2 estimation methods that can be used for determinding the slope: Sobel and Central Difference.

There are also 2 different output modes: Squared and Magnitude. The only difference is after calculating the squared gradient the mag version takes the square root to give it in absolute units. Squared mode is slightly mode efficient with one less sqrt operation but mag mode is closer to what we currently have. 

The values are similar but slightly different to the current slope calculations but much faster. We will have to re-tune the weightings for the new rover. 

Sobel with Magnitude output is very similar to our current output. Central Difference may need a secondary smoothing filter. 

Goes from 17hz -> 18hz and I expect it to scale better than current in larger maps better than our current setup.