### PR TITLE
 PLI Back-off & Framerate Control 

### DIFF
--- a/src/Cameras/video_streaming/include/video_streaming/srt_node.hpp
+++ b/src/Cameras/video_streaming/include/video_streaming/srt_node.hpp
@@ -3,9 +3,9 @@
 #include "rclcpp/rclcpp.hpp"
 #include "std_msgs/msg/empty.hpp" // I-frame
 #include "std_msgs/msg/int32.hpp" // bitrate
+#include <chrono>                 // timers
 #include <gst/gst.h>
 #include <interfaces/msg/srt_stats.hpp>
-#include <chrono> // timers
 
 namespace video_streaming {
 
@@ -13,6 +13,10 @@ class SrtNode : public BaseVideoNode {
 public:
   explicit SrtNode(const rclcpp::NodeOptions &options = rclcpp::NodeOptions());
   ~SrtNode() override;
+
+  static constexpr int INITIAL_BACKOFF_MS = 200;
+  static constexpr int MAX_BACKOFF_MS = 5000;
+  static constexpr int BACKOFF_RESET_MS = 10000;
 
 protected:
   // (interpipesrc -> nvvidconv -> nvv4l2av1enc -> srtsink)
@@ -46,18 +50,18 @@ private:
 
   rcl_interfaces::msg::SetParametersResult
   on_parameter_change(const std::vector<rclcpp::Parameter> &parameters);
-  
+
   // Backoff mechanism to avoid excessive I-frame requests
   void check_packet_loss_and_trigger(int64_t current_total_dropped);
 
   struct BackoffState {
-      int current_delay_ms = 200;      
-      int max_delay_ms = 5000;
-      int reset_ms = 10000;
+    int current_delay_ms = INITIAL_BACKOFF_MS;
+    int max_delay_ms = MAX_BACKOFF_MS;
+    int reset_ms = BACKOFF_RESET_MS;
 
-      std::chrono::steady_clock::time_point last_trigger_time;
-      std::chrono::steady_clock::time_point last_loss_time;
-      int64_t last_total_dropped_pkts = 0;
+    std::chrono::steady_clock::time_point last_trigger_time;
+    std::chrono::steady_clock::time_point last_loss_time;
+    int64_t last_total_dropped_pkts = 0;
   } backoff_state_;
 };
 

--- a/src/Cameras/video_streaming/include/video_streaming/srt_node.hpp
+++ b/src/Cameras/video_streaming/include/video_streaming/srt_node.hpp
@@ -5,6 +5,7 @@
 #include "std_msgs/msg/int32.hpp" // bitrate
 #include <gst/gst.h>
 #include <interfaces/msg/srt_stats.hpp>
+#include <chrono> // timers
 
 namespace video_streaming {
 
@@ -45,6 +46,19 @@ private:
 
   rcl_interfaces::msg::SetParametersResult
   on_parameter_change(const std::vector<rclcpp::Parameter> &parameters);
+  
+  // Backoff mechanism to avoid excessive I-frame requests
+  void check_packet_loss_and_trigger(int64_t current_total_dropped);
+
+  struct BackoffState {
+      int current_delay_ms = 200;      
+      int MAX_DELAY_MS = 5000;
+      int RESET_MS = 10000;
+
+      std::chrono::steady_clock::time_point last_trigger_time;
+      std::chrono::steady_clock::time_point last_loss_time;
+      int64_t last_total_dropped_pkts = 0;
+  } backoff_state_;
 };
 
 } // namespace video_streaming

--- a/src/Cameras/video_streaming/include/video_streaming/srt_node.hpp
+++ b/src/Cameras/video_streaming/include/video_streaming/srt_node.hpp
@@ -52,8 +52,8 @@ private:
 
   struct BackoffState {
       int current_delay_ms = 200;      
-      int MAX_DELAY_MS = 5000;
-      int RESET_MS = 10000;
+      int max_delay_ms = 5000;
+      int reset_ms = 10000;
 
       std::chrono::steady_clock::time_point last_trigger_time;
       std::chrono::steady_clock::time_point last_loss_time;

--- a/src/Cameras/video_streaming/src/srt_node.cpp
+++ b/src/Cameras/video_streaming/src/srt_node.cpp
@@ -13,12 +13,25 @@ SrtNode::SrtNode(const rclcpp::NodeOptions &options)
     : BaseVideoNode("srt_node", options) {
   RCLCPP_INFO(this->get_logger(), "Initializing SrtNode...");
 
+  // Set last trigger time to 1 hour ago so the first error triggers immediately
+  backoff_state_.last_trigger_time =
+      std::chrono::steady_clock::now() - std::chrono::hours(1);
+  backoff_state_.last_loss_time = std::chrono::steady_clock::now();
+  backoff_state_.last_total_dropped_pkts = 0;
+  backoff_state_.current_delay_ms = 200;
+
   this->declare_parameter<std::string>("srt_uri", "srt://:7001");
   this->declare_parameter<int>("latency", 100);
   this->declare_parameter<int>("iframe_interval", 0);
   this->declare_parameter<bool>("test_mode", false);
   this->declare_parameter<double>("stats_frequency", 1.0);
   this->declare_parameter<int>("target_framerate", 30);
+  this->declare_parameter<int>("backoff_max_delay_ms", 5000);
+  this->declare_parameter<int>("backoff_reset_ms", 10000);
+
+  backoff_state_.max_delay_ms =
+      this->get_parameter("backoff_max_delay_ms").as_int();
+  backoff_state_.reset_ms = this->get_parameter("backoff_reset_ms").as_int();
 
   param_callback_handle_ = this->add_on_set_parameters_callback(
       std::bind(&SrtNode::on_parameter_change, this, std::placeholders::_1));
@@ -206,6 +219,26 @@ SrtNode::on_parameter_change(const std::vector<rclcpp::Parameter> &parameters) {
       }
       continue;
     }
+
+    if (name == "backoff_max_delay_ms") {
+      int val = param.as_int();
+      if (val > 0) {
+        backoff_state_.max_delay_ms = val;
+        RCLCPP_INFO(this->get_logger(),
+                    "Param Update: Backoff Max Delay set to %d ms", val);
+      }
+      continue;
+    }
+
+    if (name == "backoff_reset_ms") {
+      int val = param.as_int();
+      if (val > 0) {
+        backoff_state_.reset_ms = val;
+        RCLCPP_INFO(this->get_logger(),
+                    "Param Update: Backoff Reset Time set to %d ms", val);
+      }
+      continue;
+    }
   }
 
   return result;
@@ -222,16 +255,69 @@ void SrtNode::on_bitrate_received(const std_msgs::msg::Int32::SharedPtr msg) {
 
 void SrtNode::on_iframe_trigger(const std_msgs::msg::Empty::SharedPtr msg) {
   (void)msg;
-  if (av1_encoder_) {
-    GstEvent *event = gst_video_event_new_downstream_force_key_unit(
-        GST_CLOCK_TIME_NONE, GST_CLOCK_TIME_NONE, GST_CLOCK_TIME_NONE, TRUE, 0);
 
-    if (gst_element_send_event(av1_encoder_, event)) {
-      RCLCPP_INFO(this->get_logger(), "I-Frame triggered (Event sent)");
+  if (srt_sink_) {
+
+    GstEvent *event = gst_video_event_new_upstream_force_key_unit(
+        GST_CLOCK_TIME_NONE, TRUE, 0);
+
+    if (gst_element_send_event(srt_sink_, event)) {
+      RCLCPP_INFO(this->get_logger(),
+                  "Manual I-Frame triggered (Upstream Event sent)");
     } else {
-      RCLCPP_WARN(this->get_logger(), "Failed to trigger I-Frame");
+      RCLCPP_WARN(this->get_logger(),
+                  "Failed to trigger Manual I-Frame (Event rejected)");
     }
+  } else {
+    RCLCPP_WARN(this->get_logger(), "Cannot trigger I-Frame: SRT Sink is null");
   }
+}
+
+void SrtNode::check_packet_loss_and_trigger(int64_t current_total_dropped) {
+  auto now = std::chrono::steady_clock::now();
+
+  if (current_total_dropped <= backoff_state_.last_total_dropped_pkts) {
+    auto time_since_loss =
+        std::chrono::duration_cast<std::chrono::milliseconds>(
+            now - backoff_state_.last_loss_time)
+            .count();
+
+    if (time_since_loss > backoff_state_.reset_ms) {
+      if (backoff_state_.current_delay_ms != 200) {
+        RCLCPP_DEBUG(this->get_logger(),
+                     "SRT connection stable. Resetting backoff.");
+      }
+      backoff_state_.current_delay_ms = 200;
+    }
+    return;
+  }
+
+  backoff_state_.last_total_dropped_pkts = current_total_dropped;
+  backoff_state_.last_loss_time = now;
+
+  auto time_since_trigger =
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+          now - backoff_state_.last_trigger_time)
+          .count();
+
+  if (time_since_trigger < backoff_state_.current_delay_ms) {
+    return;
+  }
+
+  RCLCPP_WARN(this->get_logger(),
+              "SRT Packet Drop Detected (%ld total). Requesting I-Frame! (Next "
+              "backoff: %d ms)",
+              current_total_dropped, backoff_state_.current_delay_ms * 2);
+
+  GstEvent *event =
+      gst_video_event_new_upstream_force_key_unit(GST_CLOCK_TIME_NONE, TRUE, 0);
+  if (srt_sink_) {
+    gst_element_send_event(srt_sink_, event);
+  }
+
+  backoff_state_.last_trigger_time = now;
+  backoff_state_.current_delay_ms = std::min(
+      backoff_state_.current_delay_ms * 2, backoff_state_.max_delay_ms);
 }
 
 void SrtNode::publish_srt_stats() {
@@ -292,6 +378,14 @@ void SrtNode::publish_srt_stats() {
   int ret_int = 0;
   if (gst_structure_get_int(target_stats, "packets-retransmitted", &ret_int)) {
     msg.packets_retransmitted = ret_int;
+  }
+
+  int64_t pkt_drop_total = 0;
+
+  if (gst_structure_get_int64(target_stats, "pkt-drop-total",
+                              &pkt_drop_total)) {
+    msg.packet_drop_total = pkt_drop_total;
+    check_packet_loss_and_trigger(pkt_drop_total);
   }
 
   srt_stats_pub_->publish(msg);

--- a/src/Cameras/video_streaming/src/srt_node.cpp
+++ b/src/Cameras/video_streaming/src/srt_node.cpp
@@ -6,7 +6,6 @@
 #include <gst/gststructure.h>
 #include <gst/video/video-event.h>
 #include <rclcpp_components/register_node_macro.hpp>
-
 namespace video_streaming {
 
 SrtNode::SrtNode(const rclcpp::NodeOptions &options)
@@ -18,7 +17,7 @@ SrtNode::SrtNode(const rclcpp::NodeOptions &options)
       std::chrono::steady_clock::now() - std::chrono::hours(1);
   backoff_state_.last_loss_time = std::chrono::steady_clock::now();
   backoff_state_.last_total_dropped_pkts = 0;
-  backoff_state_.current_delay_ms = 200;
+  backoff_state_.current_delay_ms = INITIAL_BACKOFF_MS;
 
   this->declare_parameter<std::string>("srt_uri", "srt://:7001");
   this->declare_parameter<int>("latency", 100);
@@ -282,42 +281,45 @@ void SrtNode::check_packet_loss_and_trigger(int64_t current_total_dropped) {
             now - backoff_state_.last_loss_time)
             .count();
 
-    if (time_since_loss > backoff_state_.reset_ms) {
-      if (backoff_state_.current_delay_ms != 200) {
-        RCLCPP_DEBUG(this->get_logger(),
-                     "SRT connection stable. Resetting backoff.");
-      }
-      backoff_state_.current_delay_ms = 200;
+    if (time_since_loss > backoff_state_.reset_ms &&
+        backoff_state_.current_delay_ms != INITIAL_BACKOFF_MS) {
+      RCLCPP_DEBUG(this->get_logger(),
+                   "SRT connection stable. Resetting backoff.");
     }
-    return;
+    backoff_state_.current_delay_ms = INITIAL_BACKOFF_MS;
   }
+  return;
+}
 
-  backoff_state_.last_total_dropped_pkts = current_total_dropped;
-  backoff_state_.last_loss_time = now;
+backoff_state_.last_total_dropped_pkts = current_total_dropped;
+backoff_state_.last_loss_time = now;
 
-  auto time_since_trigger =
-      std::chrono::duration_cast<std::chrono::milliseconds>(
-          now - backoff_state_.last_trigger_time)
-          .count();
+auto time_since_trigger = std::chrono::duration_cast<std::chrono::milliseconds>(
+                              now - backoff_state_.last_trigger_time)
+                              .count();
 
-  if (time_since_trigger < backoff_state_.current_delay_ms) {
-    return;
-  }
+if (time_since_trigger < backoff_state_.current_delay_ms) {
+  RCLCPP_DEBUG(this->get_logger(),
+               "SRT Packet Drop Detected (%ld total). Suppressing I-Frame "
+               "request (Backoff in effect)",
+               time_since_trigger, backoff_state_.current_delay_ms);
+  return;
+}
 
-  RCLCPP_WARN(this->get_logger(),
-              "SRT Packet Drop Detected (%ld total). Requesting I-Frame! (Next "
-              "backoff: %d ms)",
-              current_total_dropped, backoff_state_.current_delay_ms * 2);
+RCLCPP_WARN(this->get_logger(),
+            "SRT Packet Drop Detected (%ld total). Requesting I-Frame! (Next "
+            "backoff: %d ms)",
+            current_total_dropped, backoff_state_.current_delay_ms * 2);
 
-  GstEvent *event =
-      gst_video_event_new_upstream_force_key_unit(GST_CLOCK_TIME_NONE, TRUE, 0);
-  if (srt_sink_) {
-    gst_element_send_event(srt_sink_, event);
-  }
+GstEvent *event =
+    gst_video_event_new_upstream_force_key_unit(GST_CLOCK_TIME_NONE, TRUE, 0);
+if (srt_sink_) {
+  gst_element_send_event(srt_sink_, event);
+}
 
-  backoff_state_.last_trigger_time = now;
-  backoff_state_.current_delay_ms = std::min(
-      backoff_state_.current_delay_ms * 2, backoff_state_.max_delay_ms);
+backoff_state_.last_trigger_time = now;
+backoff_state_.current_delay_ms =
+    std::min(backoff_state_.current_delay_ms * 2, backoff_state_.max_delay_ms);
 }
 
 void SrtNode::publish_srt_stats() {

--- a/src/interfaces/msg/SrtStats.msg
+++ b/src/interfaces/msg/SrtStats.msg
@@ -5,3 +5,4 @@ float64 bandwidth      # Estimated bandwidth (in bits/sec)
 int64 packets_sent
 int64 packets_lost
 int64 packets_retransmitted
+int64 packet_drop_total


### PR DESCRIPTION
Stacked on top of PR46.

**Change(line259):** 
Now sends an upstream event to the srt_sink.

**New features:**

**Packet Loss Indication (PLI) with Back-off:**

- Implemented an exponential back-off algorithm (doubling delay) for requesting I-Frames when packet loss is detected.

- Prevents flooding the encoder with Key Unit requests during unstable network conditions.

- Configurable parameters: backoff_max_delay_ms and backoff_reset_ms.


**Dynamic Framerate Control:**

- Added support for runtime parameter updates for target_framerate.

- Videorate now updates dynamically without restarting the node when the parameter changes.


