### PR TITLE
Box blur dev

### DIFF
--- a/src/Nav/cprt_gridmap_filters/CMakeLists.txt
+++ b/src/Nav/cprt_gridmap_filters/CMakeLists.txt
@@ -42,6 +42,7 @@ set(dependencies
 
 set(filter_libs
   preserve_cost_inflation_filter
+  box_blur_filter
   gradient_filter
 )
 
@@ -59,6 +60,7 @@ include_directories(
 
 ## Declare cpp libraries
 add_library(preserve_cost_inflation_filter SHARED src/PreserveCostInflationFilter.cpp)
+add_library(box_blur_filter SHARED src/BoxBlurFilter.cpp)
 add_library(gradient_filter SHARED src/GradientFilter.cpp)
 
 foreach(lib_name ${filter_libs})

--- a/src/Nav/cprt_gridmap_filters/filter_plugins.xml
+++ b/src/Nav/cprt_gridmap_filters/filter_plugins.xml
@@ -7,6 +7,16 @@
       </description>
     </class>
   </library>
+
+    <library path="box_blur_filter">
+    <class name="cprtGridMapFilters/BoxBlurFilter" type="grid_map::BoxBlurFilter&lt;grid_map::GridMap&gt;" base_class_type="filters::FilterBase&lt;grid_map::GridMap&gt;">
+      <description>
+        Applies a box blur (mean filter) to a single layer of a GridMap. 
+        The radius of the blur should be configurable as a filter parameter. 
+        The filter should handle NaN values correctly and integrate seamlessly with the existing cprt_gridmap_filters framework.
+      </description>
+    </class>
+  </library>
   <library path="gradient_filter">
     <class name="cprtGridMapFilters/GradientFilter" type="grid_map::GradientFilter" base_class_type="filters::FilterBase&lt;grid_map::GridMap&gt;">
       <description>

--- a/src/Nav/cprt_gridmap_filters/include/BoxBlurFilter.hpp
+++ b/src/Nav/cprt_gridmap_filters/include/BoxBlurFilter.hpp
@@ -51,6 +51,8 @@ public:
   
   void VerticalBoxBlur(const Eigen::MatrixXf &layerIn,
                          Eigen::MatrixXf &layerOut, double radius);
+  
+  void MatrixMultiply(const T &mapH, const T &mapV, T &mapOut);
 
 private:
   //! Radius to take the mean from.

--- a/src/Nav/cprt_gridmap_filters/include/BoxBlurFilter.hpp
+++ b/src/Nav/cprt_gridmap_filters/include/BoxBlurFilter.hpp
@@ -8,9 +8,9 @@
 
 #ifndef CPRTGRIDMAPFILTERS_BOXBLURFILTER_HPP_
 #define CPRTGRIDMAPFILTERS_BOXBLURFILTER_HPP_
-#include <string>
-
+#include <Eigen/Dense>
 #include <filters/filter_base.hpp>
+#include <string>
 
 #include <string>
 #include <vector>
@@ -45,6 +45,12 @@ public:
    * layer.
    */
   bool update(const T &mapIn, T &mapOut) override;
+
+  void HorizontalBoxBlur(const Eigen::MatrixXf &layerIn,
+                         Eigen::MatrixXf &layerOut, double radius);
+  
+  void VerticalBoxBlur(const Eigen::MatrixXf &layerIn,
+                         Eigen::MatrixXf &layerOut, double radius);
 
 private:
   //! Radius to take the mean from.

--- a/src/Nav/cprt_gridmap_filters/include/BoxBlurFilter.hpp
+++ b/src/Nav/cprt_gridmap_filters/include/BoxBlurFilter.hpp
@@ -1,0 +1,62 @@
+/**
+ * PreserveCostInflationFilter.hpp
+ *
+ *    Created on: Oct 4th, 2025
+ *        Author: Lauren Spargo
+ *  Organization: Carleton Planetary Robotics Team
+ */
+
+#ifndef CPRTGRIDMAPFILTERS_BOXBLURFILTER_HPP_
+#define CPRTGRIDMAPFILTERS_BOXBLURFILTER_HPP_
+#include <string>
+
+#include <filters/filter_base.hpp>
+
+#include <string>
+#include <vector>
+
+namespace grid_map {
+
+/*!
+ * Filter class to find the mean of the values inside a radius.
+ */
+template <typename T> class BoxBlurFilter : public filters::FilterBase<T> {
+public:
+  /*!
+   * Constructor
+   */
+  BoxBlurFilter();
+
+  /*!
+   * Destructor.
+   */
+  virtual ~BoxBlurFilter();
+
+  /*!
+   * Configures the filter from parameters on the Parameter Server
+   */
+  bool configure() override;
+
+  /*!
+   * Computes for each value in the input layer the mean of all values in a
+   * radius around it Saves this mean in an additional output layer.
+   * @param mapIn grid map containing the input layer.
+   * @param mapOut grid map containing the layers of the input map and the new
+   * layer.
+   */
+  bool update(const T &mapIn, T &mapOut) override;
+
+private:
+  //! Radius to take the mean from.
+  double radius_;
+
+  //! Input layer name.
+  std::string inputLayer_;
+
+  //! Output layer name.
+  std::string outputLayer_;
+};
+
+} // namespace grid_map
+
+#endif // CPRTGRIDMAPFILTERS_PRESERVECOSTINFLATIONFILTER_HPP_

--- a/src/Nav/cprt_gridmap_filters/include/BoxBlurFilter.hpp
+++ b/src/Nav/cprt_gridmap_filters/include/BoxBlurFilter.hpp
@@ -47,18 +47,19 @@ public:
   bool update(const T &mapIn, T &mapOut) override;
 
   void HorizontalBoxBlur(const Eigen::MatrixXf &layerIn,
-                         Eigen::MatrixXf &layerOut, double radius);
-  
-  void VerticalBoxBlur(const Eigen::MatrixXf &layerIn,
-                         Eigen::MatrixXf &layerOut, double radius);
-  
-  //void MatrixMultiply(const T &mapH, const T &mapV, T &mapOut);
+                         Eigen::MatrixXf &layerOut, int r);
 
-  //void MatrixMultiply(const Eigen::MatrixXf &layerHorz, const Eigen::MatrixXf &layerVert, Eigen::MatrixXf &layerOut) 
+  void VerticalBoxBlur(const Eigen::MatrixXf &layerIn,
+                       Eigen::MatrixXf &layerOut, int r);
+
+  // void MatrixMultiply(const T &mapH, const T &mapV, T &mapOut);
+
+  // void MatrixMultiply(const Eigen::MatrixXf &layerHorz, const Eigen::MatrixXf
+  // &layerVert, Eigen::MatrixXf &layerOut)
 
 private:
   //! Radius to take the mean from.
-  double radius_;
+  int radius_;
 
   //! Input layer name.
   std::string inputLayer_;

--- a/src/Nav/cprt_gridmap_filters/include/BoxBlurFilter.hpp
+++ b/src/Nav/cprt_gridmap_filters/include/BoxBlurFilter.hpp
@@ -52,7 +52,9 @@ public:
   void VerticalBoxBlur(const Eigen::MatrixXf &layerIn,
                          Eigen::MatrixXf &layerOut, double radius);
   
-  void MatrixMultiply(const T &mapH, const T &mapV, T &mapOut);
+  //void MatrixMultiply(const T &mapH, const T &mapV, T &mapOut);
+
+  //void MatrixMultiply(const Eigen::MatrixXf &layerHorz, const Eigen::MatrixXf &layerVert, Eigen::MatrixXf &layerOut) 
 
 private:
   //! Radius to take the mean from.

--- a/src/Nav/cprt_gridmap_filters/include/BoxBlurFilter.hpp
+++ b/src/Nav/cprt_gridmap_filters/include/BoxBlurFilter.hpp
@@ -1,5 +1,5 @@
 /**
- * PreserveCostInflationFilter.hpp
+ * BoxBlur.hpp
  *
  *    Created on: Oct 4th, 2025
  *        Author: Lauren Spargo
@@ -46,16 +46,16 @@ public:
    */
   bool update(const T &mapIn, T &mapOut) override;
 
-  void HorizontalBoxBlur(const Eigen::MatrixXf &layerIn,
-                         Eigen::MatrixXf &layerOut, int r);
+  /*!
+   * Averages (unweighted) [2*radius + 1] cells at a time along the rows of a gridmap layer
+   */
+  void HorizontalBoxBlur(const Eigen::MatrixXf &layerIn, Eigen::MatrixXf &layerOut, int r);
 
-  void VerticalBoxBlur(const Eigen::MatrixXf &layerIn,
-                       Eigen::MatrixXf &layerOut, int r);
-
-  // void MatrixMultiply(const T &mapH, const T &mapV, T &mapOut);
-
-  // void MatrixMultiply(const Eigen::MatrixXf &layerHorz, const Eigen::MatrixXf
-  // &layerVert, Eigen::MatrixXf &layerOut)
+  /*!
+   * Averages (unweighted) [2*radius + 1] cells at a time along the columns of a gridmap layer,
+   * called subsequently after HorizontalBoxBlur() to complete the box blur
+   */
+  void VerticalBoxBlur(const Eigen::MatrixXf &layerIn, Eigen::MatrixXf &layerOut, int r);
 
 private:
   //! Radius to take the mean from.
@@ -70,4 +70,4 @@ private:
 
 } // namespace grid_map
 
-#endif // CPRTGRIDMAPFILTERS_PRESERVECOSTINFLATIONFILTER_HPP_
+#endif // CPRTGRIDMAPFILTERS_BOXBLURFILTER_HPP_

--- a/src/Nav/cprt_gridmap_filters/include/BoxBlurFilter.hpp
+++ b/src/Nav/cprt_gridmap_filters/include/BoxBlurFilter.hpp
@@ -47,15 +47,19 @@ public:
   bool update(const T &mapIn, T &mapOut) override;
 
   /*!
-   * Averages (unweighted) [2*radius + 1] cells at a time along the rows of a gridmap layer
+   * Averages (unweighted) [2*radius + 1] cells at a time along the rows of a
+   * gridmap layer
    */
-  void HorizontalBoxBlur(const Eigen::MatrixXf &layerIn, Eigen::MatrixXf &layerOut, int r);
+  void HorizontalBoxBlur(const Eigen::MatrixXf &layerIn,
+                         Eigen::MatrixXf &layerOut, int r);
 
   /*!
-   * Averages (unweighted) [2*radius + 1] cells at a time along the columns of a gridmap layer,
-   * called subsequently after HorizontalBoxBlur() to complete the box blur
+   * Averages (unweighted) [2*radius + 1] cells at a time along the columns of a
+   * gridmap layer, called subsequently after HorizontalBoxBlur() to complete
+   * the box blur
    */
-  void VerticalBoxBlur(const Eigen::MatrixXf &layerIn, Eigen::MatrixXf &layerOut, int r);
+  void VerticalBoxBlur(const Eigen::MatrixXf &layerIn,
+                       Eigen::MatrixXf &layerOut, int r);
 
 private:
   //! Radius to take the mean from.

--- a/src/Nav/cprt_gridmap_filters/src/BoxBlurFilter.cpp
+++ b/src/Nav/cprt_gridmap_filters/src/BoxBlurFilter.cpp
@@ -93,7 +93,7 @@ void BoxBlurFilter<T>::HorizontalBoxBlur(const Eigen::MatrixXf &layerIn, Eigen::
     for (int x = 0; x < width; x++) {
       //ensuring that max and min cells in radius do not exceed dimensions of gridmap layer
       const int minCoeff = std::max(0, x - r);
-      int maxCoeff = std::min(width - 1, x + r);
+      const int maxCoeff = std::min(width - 1, x + r);
       int numHoles = 0;
       double sum = 0;
 

--- a/src/Nav/cprt_gridmap_filters/src/BoxBlurFilter.cpp
+++ b/src/Nav/cprt_gridmap_filters/src/BoxBlurFilter.cpp
@@ -92,7 +92,7 @@ void BoxBlurFilter<T>::HorizontalBoxBlur(const Eigen::MatrixXf &layerIn, Eigen::
   for (int y = 0; y < height; y++) {
     for (int x = 0; x < width; x++) {
       //ensuring that max and min cells in radius do not exceed dimensions of gridmap layer
-      int minCoeff = std::max(0, x - r);
+      const int minCoeff = std::max(0, x - r);
       int maxCoeff = std::min(width - 1, x + r);
       int numHoles = 0;
       double sum = 0;

--- a/src/Nav/cprt_gridmap_filters/src/BoxBlurFilter.cpp
+++ b/src/Nav/cprt_gridmap_filters/src/BoxBlurFilter.cpp
@@ -32,13 +32,13 @@ template <typename T> bool BoxBlurFilter<T>::configure() {
     return false;
   }
 
-  if (radius_ < 0.0) {
+  if (radius_ < 0) {
     RCLCPP_ERROR(this->logging_interface_->get_logger(),
                  "BoxBlur filter: Radius must be greater than zero.");
     return false;
   }
 
-  RCLCPP_DEBUG(this->logging_interface_->get_logger(), "Radius = %f.", radius_);
+  RCLCPP_DEBUG(this->logging_interface_->get_logger(), "Radius = %d.", radius_);
 
   if (!param_reader.get(std::string("input_layer"), inputLayer_)) {
     RCLCPP_ERROR(this->logging_interface_->get_logger(),
@@ -66,8 +66,8 @@ template <typename T> bool BoxBlurFilter<T>::update(const T &mapIn, T &mapOut) {
   T mapOutHorz = mapIn;
 
   // Check if layer(s) exist
-  if (!mapOut.exists(this->inputLayer_) || !mapOutHorz.exists(this->inputLayer_)) 
-  {
+  if (!mapOut.exists(this->inputLayer_) ||
+      !mapOutHorz.exists(this->inputLayer_)) {
     RCLCPP_ERROR(this->logging_interface_->get_logger(),
                  "Layer %s does not exist. Unable to apply box blur"
                  "filter.",
@@ -78,58 +78,60 @@ template <typename T> bool BoxBlurFilter<T>::update(const T &mapIn, T &mapOut) {
   mapOut.add(this->outputLayer_);
   mapOutHorz.add(this->outputLayer_);
 
-  HorizontalBoxBlur(mapIn[outputLayer_], mapOutHorz[outputLayer_], radius_);
+  HorizontalBoxBlur(mapIn[inputLayer_], mapOutHorz[outputLayer_], radius_);
   VerticalBoxBlur(mapOutHorz[outputLayer_], mapOut[outputLayer_], radius_);
   return true;
 }
 
-void HorizontalBoxBlur(
-    const Eigen::MatrixXf &layerIn, Eigen::MatrixXf &layerOut,
-    double radius)
-{
- 
+template <typename T>
+void BoxBlurFilter<T>::HorizontalBoxBlur(const Eigen::MatrixXf &layerIn,
+                                         Eigen::MatrixXf &layerOut, int r) {
+
   int height = layerOut.rows();
   int width = layerOut.cols();
-  int r = (int)radius;
 
-  for(int y = 0; y < height; y++)
-  {
-    for(int x = 0; x < width; x++)
-    {
+  for (int y = 0; y < height; y++) {
+    for (int x = 0; x < width; x++) {
       int minCoeff = std::max(0, x - r);
       int maxCoeff = std::min(width - 1, x + r);
+      int numHoles = 0;
       double sum = 0;
 
-      for(int i = minCoeff; i <= maxCoeff; i++)
-      {
-        sum += layerIn(i, y);
+      for (int i = minCoeff; i <= maxCoeff; i++) {
+        const float value = layerIn(i, y);
+        if (!std::isfinite(value)) {
+          numHoles += 1;
+          continue;
+        }
+        sum += value;
       }
-      layerOut(x, y) = sum/(maxCoeff - minCoeff + 1);
+      layerOut(x, y) = sum / (maxCoeff - minCoeff + 1 - numHoles);
     }
   }
 }
 
-void VerticalBoxBlur(
-    const Eigen::MatrixXf &layerIn, Eigen::MatrixXf &layerOut,
-    double radius)
-{
+template <typename T>
+void BoxBlurFilter<T>::VerticalBoxBlur(const Eigen::MatrixXf &layerIn,
+                                       Eigen::MatrixXf &layerOut, int r) {
   int height = layerOut.rows();
   int width = layerOut.cols();
-  int r = (int)radius;
 
-  for(int x = 0; x < width; x++)
-  {
-    for(int y = 0; y < height; y++)
-    {
+  for (int x = 0; x < width; x++) {
+    for (int y = 0; y < height; y++) {
       int minCoeff = std::max(0, y - r);
       int maxCoeff = std::min(height - 1, y + r);
+      int numHoles = 0;
       double sum = 0;
 
-      for(int i = minCoeff; i <= maxCoeff; i++)
-      {
-        sum += layerIn(x, i);
+      for (int i = minCoeff; i <= maxCoeff; i++) {
+        const float value = layerIn(x, i);
+        if (!std::isfinite(value)) {
+          numHoles += 1;
+          continue;
+        }
+        sum += value;
       }
-      layerOut(x, y) = sum/(maxCoeff - minCoeff + 1);
+      layerOut(x, y) = sum / (maxCoeff - minCoeff + 1 - numHoles);
     }
   }
 }

--- a/src/Nav/cprt_gridmap_filters/src/BoxBlurFilter.cpp
+++ b/src/Nav/cprt_gridmap_filters/src/BoxBlurFilter.cpp
@@ -1,0 +1,99 @@
+/**
+ * PreserveCostInflationFilter.hpp
+ *
+ *    Created on: Oct 4th, 2025
+ *        Author: Lauren Spargo
+ *  Organization: Carleton Planetary Robotics Team
+ */
+
+#include "BoxBlurFilter.hpp"
+
+#include <grid_map_core/grid_map_core.hpp>
+#include <pluginlib/class_list_macros.hpp>
+
+#include <string>
+
+#include "grid_map_cv/utilities.hpp"
+
+namespace grid_map {
+
+template <typename T> BoxBlurFilter<T>::BoxBlurFilter() : radius_(0.0) {}
+
+template <typename T> BoxBlurFilter<T>::~BoxBlurFilter() {}
+
+template <typename T> bool BoxBlurFilter<T>::configure() {
+  ParameterReader param_reader(this->param_prefix_, this->params_interface_);
+
+  if (!param_reader.get(std::string("radius"), radius_)) {
+    RCLCPP_ERROR(this->logging_interface_->get_logger(),
+                 "MeanInRadius filter did not find parameter `radius`.");
+    return false;
+  }
+
+  if (radius_ < 0.0) {
+    RCLCPP_ERROR(this->logging_interface_->get_logger(),
+                 "MeanInRadius filter: Radius must be greater than zero.");
+    return false;
+  }
+
+  RCLCPP_DEBUG(this->logging_interface_->get_logger(), "Radius = %f.", radius_);
+
+  if (!param_reader.get(std::string("input_layer"), inputLayer_)) {
+    RCLCPP_ERROR(this->logging_interface_->get_logger(),
+                 "MeanInRadius filter did not find parameter `input_layer`.");
+    return false;
+  }
+
+  RCLCPP_DEBUG(this->logging_interface_->get_logger(),
+               "MeanInRadius input layer is = %s.", inputLayer_.c_str());
+
+  if (!param_reader.get(std::string("output_layer"), outputLayer_)) {
+    RCLCPP_ERROR(this->logging_interface_->get_logger(),
+                 "MeanInRadius filter did not find parameter `output_layer`.");
+    return false;
+  }
+
+  RCLCPP_DEBUG(this->logging_interface_->get_logger(),
+               "MeanInRadius output_layer = %s.", outputLayer_.c_str());
+  return true;
+}
+
+template <typename T> bool BoxBlurFilter<T>::update(const T &mapIn, T &mapOut) {
+  // Add new layers to the elevation map.
+  mapOut = mapIn;
+  mapOut.add(outputLayer_);
+
+  double value;
+
+  // First iteration through the elevation map.
+  for (grid_map::GridMapIterator iterator(mapOut); !iterator.isPastEnd();
+       ++iterator) {
+    double valueSum = 0.0;
+    int counter = 0;
+    // Requested position (center) of circle in map.
+    Eigen::Vector2d center;
+    mapOut.getPosition(*iterator, center);
+
+    // Find the mean in a circle around the center
+    for (grid_map::CircleIterator submapIterator(mapOut, center, radius_);
+         !submapIterator.isPastEnd(); ++submapIterator) {
+      if (!mapOut.isValid(*submapIterator, inputLayer_)) {
+        continue;
+      }
+      value = mapOut.at(inputLayer_, *submapIterator);
+      valueSum += value;
+      counter++;
+    }
+
+    if (counter != 0) {
+      mapOut.at(outputLayer_, *iterator) = valueSum / counter;
+    }
+  }
+
+  return true;
+}
+
+} // namespace grid_map
+
+PLUGINLIB_EXPORT_CLASS(grid_map::BoxBlurFilter<grid_map::GridMap>,
+                       filters::FilterBase<grid_map::GridMap>)

--- a/src/Nav/cprt_gridmap_filters/src/BoxBlurFilter.cpp
+++ b/src/Nav/cprt_gridmap_filters/src/BoxBlurFilter.cpp
@@ -62,40 +62,15 @@ template <typename T> bool BoxBlurFilter<T>::configure() {
 
 template <typename T> bool BoxBlurFilter<T>::update(const T &mapIn, T &mapOut) {
   // Add new layers to the elevation map.
-  mapOut = mapIn;
-  mapOut.add(outputLayer_);
+  T mapOutHorz = mapIn;
+  T mapOutVert = mapIn;
+  //mapOut.add(outputLayer_);
 
-  HorizontalBoxBlur(mapIn[outputLayer_], mapOut[outputLayer_], radius_);
+  HorizontalBoxBlur(mapIn[outputLayer_], mapOutHorz[outputLayer_], radius_);
+  VerticalBoxBlur(mapIn[outputLayer_], mapOutVert[outputLayer_], radius_);
 
-  //VerticalBoxBlur(mapIn[outputLayer_], mapOut[outputLayer_], radius_);
-
-  double value;
-
-  // First iteration through the elevation map.
-  for (grid_map::GridMapIterator iterator(mapOut); !iterator.isPastEnd();
-       ++iterator) {
-    double valueSum = 0.0;
-    int counter = 0;
-    // Requested position (center) of circle in map.
-    Eigen::Vector2d center;
-    mapOut.getPosition(*iterator, center);
-
-    // Find the mean in a circle around the center
-    for (grid_map::CircleIterator submapIterator(mapOut, center, radius_);
-         !submapIterator.isPastEnd(); ++submapIterator) {
-      if (!mapOut.isValid(*submapIterator, inputLayer_)) {
-        continue;
-      }
-      value = mapOut.at(inputLayer_, *submapIterator);
-      valueSum += value;
-      counter++;
-    }
-
-    if (counter != 0) {
-      mapOut.at(outputLayer_, *iterator) = valueSum / counter;
-    }
-  }
-
+  MatrixMultiply(mapOutHorz, mapOutVert, mapOut);
+  
   return true;
 }
 
@@ -104,49 +79,59 @@ template <typename T> bool BoxBlurFilter<T>::update(const T &mapIn, T &mapOut) {
 // finished!
 void HorizontalBoxBlur(
     const Eigen::MatrixXf &layerIn, Eigen::MatrixXf &layerOut,
-    double radius) // Unsure about parameter types.. ask about const + &!
+    double radius)
 {
-  layerOut = layerIn; // is this necessary?
-  float avgDenominator = 2 * radius + 1;
+ 
+  int height = layerOut.rows();
+  int width = layerOut.cols();
+  int r = (int)radius;
 
-  for (int y = 0; y <= layerOut.cols(); y++) { // Loop through columns
-    float minusCoeff;
-    float plusCoeff;
-    double sum = 0;
+  for(int y = 0; y < height; y++)
+  {
+    for(int x = 0; x < width; x++)
+    {
+      int minCoeff = std::max(0, x - r);
+      int maxCoeff = std::min(width - 1, x + r);
+      double sum = 0;
 
-    for (int x = 0; x <= layerOut.rows(); x++) { // Loop through rows
-      if (x == 0) {
-        minusCoeff = 0;
-      } else {
-        minusCoeff = layerOut(x - 1, y); // layerOut.getCoeff(x - 1, y);
+      for(int i = minCoeff; i <= maxCoeff; i++)
+      {
+        sum += layerIn(i, y);
       }
-
-      if (x + 1 <= layerOut.rows()) {
-        plusCoeff = layerOut(x + 1, y); // layerOut.getCoeff(x + 1, y);
-      } else {
-        plusCoeff = 0;
-      }
-
-      sum = plusCoeff - minusCoeff + sum;
-      layerOut(x, y) = sum / avgDenominator;
+      layerOut(x, y) = sum/(maxCoeff - minCoeff + 1);
     }
   }
 }
-/*
+
 void VerticalBoxBlur(
     const Eigen::MatrixXf &layerIn, Eigen::MatrixXf &layerOut,
-    double radius) // Unsure about parameter types.. ask about const + &!
+    double radius)
 {
-  //Fill in when horizontal algorithm works properly
+  int height = layerOut.rows();
+  int width = layerOut.cols();
+  int r = (int)radius;
+
+  for(int x = 0; x < width; x++)
+  {
+    for(int y = 0; y < height; y++)
+    {
+      int minCoeff = std::max(0, y - r);
+      int maxCoeff = std::min(height - 1, y + r);
+      double sum = 0;
+
+      for(int i = minCoeff; i <= maxCoeff; i++)
+      {
+        sum += layerIn(x, i);
+      }
+      layerOut(x, y) = sum/(maxCoeff - minCoeff + 1);
+    }
+  }
 }
 
-void MatrixMultiply(
-    const Eigen::MatrixXf &layerIn, Eigen::MatrixXf &layerOut,
-    double radius) // Unsure about parameter types.. ask about const + &!
+template <typename T> void BoxBlurFilter<T>::MatrixMultiply(const T &mapH, const T &mapV, T &mapOut)
 {
   //Fill in when horizontal algorithm works properly
 }
-*/
 
 } // namespace grid_map
 

--- a/src/Nav/cprt_gridmap_filters/src/BoxBlurFilter.cpp
+++ b/src/Nav/cprt_gridmap_filters/src/BoxBlurFilter.cpp
@@ -86,7 +86,7 @@ template <typename T> bool BoxBlurFilter<T>::update(const T &mapIn, T &mapOut) {
 template <typename T>
 void BoxBlurFilter<T>::HorizontalBoxBlur(const Eigen::MatrixXf &layerIn, Eigen::MatrixXf &layerOut, int r) 
 {
-  int height = layerOut.rows();
+  const int height = layerOut.rows();
   int width = layerOut.cols();
 
   for (int y = 0; y < height; y++) {

--- a/src/Nav/cprt_gridmap_filters/src/BoxBlurFilter.cpp
+++ b/src/Nav/cprt_gridmap_filters/src/BoxBlurFilter.cpp
@@ -32,7 +32,7 @@ template <typename T> bool BoxBlurFilter<T>::configure() {
     return false;
   }
 
-  if (radius_ < 0) {
+  if (radius_ <= 0) {
     RCLCPP_ERROR(this->logging_interface_->get_logger(),
                  "BoxBlur filter: Radius must be greater than zero.");
     return false;

--- a/src/Nav/cprt_gridmap_filters/src/BoxBlurFilter.cpp
+++ b/src/Nav/cprt_gridmap_filters/src/BoxBlurFilter.cpp
@@ -8,6 +8,8 @@
 
 #include "BoxBlurFilter.hpp"
 
+#include <Eigen/Dense>
+
 #include <grid_map_core/grid_map_core.hpp>
 #include <pluginlib/class_list_macros.hpp>
 
@@ -16,7 +18,7 @@
 #include "grid_map_cv/utilities.hpp"
 
 namespace grid_map {
-
+// Error trapping for invalid parameters
 template <typename T> BoxBlurFilter<T>::BoxBlurFilter() : radius_(0.0) {}
 
 template <typename T> BoxBlurFilter<T>::~BoxBlurFilter() {}
@@ -26,13 +28,13 @@ template <typename T> bool BoxBlurFilter<T>::configure() {
 
   if (!param_reader.get(std::string("radius"), radius_)) {
     RCLCPP_ERROR(this->logging_interface_->get_logger(),
-                 "MeanInRadius filter did not find parameter `radius`.");
+                 "BoxBlur filter did not find parameter `radius`.");
     return false;
   }
 
   if (radius_ < 0.0) {
     RCLCPP_ERROR(this->logging_interface_->get_logger(),
-                 "MeanInRadius filter: Radius must be greater than zero.");
+                 "BoxBlur filter: Radius must be greater than zero.");
     return false;
   }
 
@@ -40,21 +42,21 @@ template <typename T> bool BoxBlurFilter<T>::configure() {
 
   if (!param_reader.get(std::string("input_layer"), inputLayer_)) {
     RCLCPP_ERROR(this->logging_interface_->get_logger(),
-                 "MeanInRadius filter did not find parameter `input_layer`.");
+                 "BoxBlur filter did not find parameter `input_layer`.");
     return false;
   }
 
   RCLCPP_DEBUG(this->logging_interface_->get_logger(),
-               "MeanInRadius input layer is = %s.", inputLayer_.c_str());
+               "BoxBlur input layer is = %s.", inputLayer_.c_str());
 
   if (!param_reader.get(std::string("output_layer"), outputLayer_)) {
     RCLCPP_ERROR(this->logging_interface_->get_logger(),
-                 "MeanInRadius filter did not find parameter `output_layer`.");
+                 "BoxBlur filter did not find parameter `output_layer`.");
     return false;
   }
 
   RCLCPP_DEBUG(this->logging_interface_->get_logger(),
-               "MeanInRadius output_layer = %s.", outputLayer_.c_str());
+               "BoxBlur output_layer = %s.", outputLayer_.c_str());
   return true;
 }
 
@@ -62,6 +64,10 @@ template <typename T> bool BoxBlurFilter<T>::update(const T &mapIn, T &mapOut) {
   // Add new layers to the elevation map.
   mapOut = mapIn;
   mapOut.add(outputLayer_);
+
+  HorizontalBoxBlur(mapIn[outputLayer_], mapOut[outputLayer_], radius_);
+
+  //VerticalBoxBlur(mapIn[outputLayer_], mapOut[outputLayer_], radius_);
 
   double value;
 
@@ -92,6 +98,55 @@ template <typename T> bool BoxBlurFilter<T>::update(const T &mapIn, T &mapOut) {
 
   return true;
 }
+
+// Implement SEPARATE (for separable boxblur) horizontal and vertical blur
+// functions, call one after the other Don't forget to add to header file when
+// finished!
+void HorizontalBoxBlur(
+    const Eigen::MatrixXf &layerIn, Eigen::MatrixXf &layerOut,
+    double radius) // Unsure about parameter types.. ask about const + &!
+{
+  layerOut = layerIn; // is this necessary?
+  float avgDenominator = 2 * radius + 1;
+
+  for (int y = 0; y <= layerOut.cols(); y++) { // Loop through columns
+    float minusCoeff;
+    float plusCoeff;
+    double sum = 0;
+
+    for (int x = 0; x <= layerOut.rows(); x++) { // Loop through rows
+      if (x == 0) {
+        minusCoeff = 0;
+      } else {
+        minusCoeff = layerOut(x - 1, y); // layerOut.getCoeff(x - 1, y);
+      }
+
+      if (x + 1 <= layerOut.rows()) {
+        plusCoeff = layerOut(x + 1, y); // layerOut.getCoeff(x + 1, y);
+      } else {
+        plusCoeff = 0;
+      }
+
+      sum = plusCoeff - minusCoeff + sum;
+      layerOut(x, y) = sum / avgDenominator;
+    }
+  }
+}
+/*
+void VerticalBoxBlur(
+    const Eigen::MatrixXf &layerIn, Eigen::MatrixXf &layerOut,
+    double radius) // Unsure about parameter types.. ask about const + &!
+{
+  //Fill in when horizontal algorithm works properly
+}
+
+void MatrixMultiply(
+    const Eigen::MatrixXf &layerIn, Eigen::MatrixXf &layerOut,
+    double radius) // Unsure about parameter types.. ask about const + &!
+{
+  //Fill in when horizontal algorithm works properly
+}
+*/
 
 } // namespace grid_map
 

--- a/src/Nav/cprt_gridmap_filters/src/BoxBlurFilter.cpp
+++ b/src/Nav/cprt_gridmap_filters/src/BoxBlurFilter.cpp
@@ -1,5 +1,5 @@
 /**
- * PreserveCostInflationFilter.hpp
+ * BoxBlurFilter.hpp
  *
  *    Created on: Oct 4th, 2025
  *        Author: Lauren Spargo
@@ -18,7 +18,7 @@
 #include "grid_map_cv/utilities.hpp"
 
 namespace grid_map {
-// Error trapping for invalid parameters
+//Error trapping for invalid parameters
 template <typename T> BoxBlurFilter<T>::BoxBlurFilter() : radius_(0.0) {}
 
 template <typename T> BoxBlurFilter<T>::~BoxBlurFilter() {}
@@ -61,7 +61,6 @@ template <typename T> bool BoxBlurFilter<T>::configure() {
 }
 
 template <typename T> bool BoxBlurFilter<T>::update(const T &mapIn, T &mapOut) {
-  // Add new layers to the elevation map
   mapOut = mapIn;
   T mapOutHorz = mapIn;
 
@@ -78,20 +77,21 @@ template <typename T> bool BoxBlurFilter<T>::update(const T &mapIn, T &mapOut) {
   mapOut.add(this->outputLayer_);
   mapOutHorz.add(this->outputLayer_);
 
-  HorizontalBoxBlur(mapIn[inputLayer_], mapOutHorz[outputLayer_], radius_);
-  VerticalBoxBlur(mapOutHorz[outputLayer_], mapOut[outputLayer_], radius_);
+  HorizontalBoxBlur(mapIn[inputLayer_], mapOutHorz[outputLayer_], radius_); //Blurs input layer from mapIn horizontally, saves blurred values to mapOutHorz on outputLayer_
+  VerticalBoxBlur(mapOutHorz[outputLayer_], mapOut[outputLayer_], radius_); //Blurs outputLayer_ from mapOutHorz vertically, saves blurred values to mapOut on outputLayer_
+  //Box blur complete!
   return true;
 }
 
 template <typename T>
-void BoxBlurFilter<T>::HorizontalBoxBlur(const Eigen::MatrixXf &layerIn,
-                                         Eigen::MatrixXf &layerOut, int r) {
-
+void BoxBlurFilter<T>::HorizontalBoxBlur(const Eigen::MatrixXf &layerIn, Eigen::MatrixXf &layerOut, int r) 
+{
   int height = layerOut.rows();
   int width = layerOut.cols();
 
   for (int y = 0; y < height; y++) {
     for (int x = 0; x < width; x++) {
+      //ensuring that max and min cells in radius do not exceed dimensions of gridmap layer
       int minCoeff = std::max(0, x - r);
       int maxCoeff = std::min(width - 1, x + r);
       int numHoles = 0;
@@ -99,20 +99,23 @@ void BoxBlurFilter<T>::HorizontalBoxBlur(const Eigen::MatrixXf &layerIn,
 
       for (int i = minCoeff; i <= maxCoeff; i++) {
         const float value = layerIn(i, y);
-        if (!std::isfinite(value)) {
-          numHoles += 1;
+        if (!std::isfinite(value)) //checking for hole
+        {
+          numHoles += 1; //if hole found, disregard it and continue
           continue;
         }
         sum += value;
       }
+      //calculate and write average to layerOut
       layerOut(x, y) = sum / (maxCoeff - minCoeff + 1 - numHoles);
     }
   }
 }
 
 template <typename T>
-void BoxBlurFilter<T>::VerticalBoxBlur(const Eigen::MatrixXf &layerIn,
-                                       Eigen::MatrixXf &layerOut, int r) {
+void BoxBlurFilter<T>::VerticalBoxBlur(const Eigen::MatrixXf &layerIn, Eigen::MatrixXf &layerOut, int r) 
+{
+  //Same algorithm as horizontal box blur, only along a column rather than a row
   int height = layerOut.rows();
   int width = layerOut.cols();
 
@@ -136,31 +139,6 @@ void BoxBlurFilter<T>::VerticalBoxBlur(const Eigen::MatrixXf &layerIn,
   }
 }
 
-#if 0
-{
-  template <typename T> void BoxBlurFilter<T>::MatrixMultiply(const T &mapH, const T &mapV, T &mapOut) 
-  //wondering if I should only be passing in LAYERS rather than the whole map for more efficiency?? idk enough abt Eigen tbh
-  //TODO: ask Connor (or Darren or Erik!) above question ^^
-  {
-    //Fill in when horizontal algorithm works properly
-    mapOut = mapH*mapV;
-  }
-}
-#endif
-
-#if 0
-{
-  void MatrixMultiply(const Eigen::MatrixXf &layerHorz, const Eigen::MatrixXf &layerVert, Eigen::MatrixXf &layerOut) 
-  {
-    //layerOut = layerHorz*layerVert;
-    //wondering if I should only be passing in LAYERS rather than the whole map for more efficiency?? idk enough abt Eigen tbh
-    //TODO: ask Connor (or Darren or Erik!) above question ^^
-
-    layerOut = layerHorz.dot(layerVert);
-
-  }
-}
-#endif
 } // namespace grid_map
 
 PLUGINLIB_EXPORT_CLASS(grid_map::BoxBlurFilter<grid_map::GridMap>,

--- a/src/Nav/cprt_gridmap_filters/src/BoxBlurFilter.cpp
+++ b/src/Nav/cprt_gridmap_filters/src/BoxBlurFilter.cpp
@@ -61,22 +61,28 @@ template <typename T> bool BoxBlurFilter<T>::configure() {
 }
 
 template <typename T> bool BoxBlurFilter<T>::update(const T &mapIn, T &mapOut) {
-  // Add new layers to the elevation map.
+  // Add new layers to the elevation map
+  mapOut = mapIn;
   T mapOutHorz = mapIn;
-  T mapOutVert = mapIn;
-  //mapOut.add(outputLayer_);
+
+  // Check if layer(s) exist
+  if (!mapOut.exists(this->inputLayer_) || !mapOutHorz.exists(this->inputLayer_)) 
+  {
+    RCLCPP_ERROR(this->logging_interface_->get_logger(),
+                 "Layer %s does not exist. Unable to apply box blur"
+                 "filter.",
+                 this->inputLayer_.c_str());
+    return false;
+  }
+
+  mapOut.add(this->outputLayer_);
+  mapOutHorz.add(this->outputLayer_);
 
   HorizontalBoxBlur(mapIn[outputLayer_], mapOutHorz[outputLayer_], radius_);
-  VerticalBoxBlur(mapIn[outputLayer_], mapOutVert[outputLayer_], radius_);
-
-  MatrixMultiply(mapOutHorz, mapOutVert, mapOut);
-  
+  VerticalBoxBlur(mapOutHorz[outputLayer_], mapOut[outputLayer_], radius_);
   return true;
 }
 
-// Implement SEPARATE (for separable boxblur) horizontal and vertical blur
-// functions, call one after the other Don't forget to add to header file when
-// finished!
 void HorizontalBoxBlur(
     const Eigen::MatrixXf &layerIn, Eigen::MatrixXf &layerOut,
     double radius)
@@ -128,11 +134,31 @@ void VerticalBoxBlur(
   }
 }
 
-template <typename T> void BoxBlurFilter<T>::MatrixMultiply(const T &mapH, const T &mapV, T &mapOut)
+#if 0
 {
-  //Fill in when horizontal algorithm works properly
+  template <typename T> void BoxBlurFilter<T>::MatrixMultiply(const T &mapH, const T &mapV, T &mapOut) 
+  //wondering if I should only be passing in LAYERS rather than the whole map for more efficiency?? idk enough abt Eigen tbh
+  //TODO: ask Connor (or Darren or Erik!) above question ^^
+  {
+    //Fill in when horizontal algorithm works properly
+    mapOut = mapH*mapV;
+  }
 }
+#endif
 
+#if 0
+{
+  void MatrixMultiply(const Eigen::MatrixXf &layerHorz, const Eigen::MatrixXf &layerVert, Eigen::MatrixXf &layerOut) 
+  {
+    //layerOut = layerHorz*layerVert;
+    //wondering if I should only be passing in LAYERS rather than the whole map for more efficiency?? idk enough abt Eigen tbh
+    //TODO: ask Connor (or Darren or Erik!) above question ^^
+
+    layerOut = layerHorz.dot(layerVert);
+
+  }
+}
+#endif
 } // namespace grid_map
 
 PLUGINLIB_EXPORT_CLASS(grid_map::BoxBlurFilter<grid_map::GridMap>,

--- a/src/Nav/cprt_gridmap_filters/src/BoxBlurFilter.cpp
+++ b/src/Nav/cprt_gridmap_filters/src/BoxBlurFilter.cpp
@@ -87,7 +87,7 @@ template <typename T>
 void BoxBlurFilter<T>::HorizontalBoxBlur(const Eigen::MatrixXf &layerIn, Eigen::MatrixXf &layerOut, int r) 
 {
   const int height = layerOut.rows();
-  int width = layerOut.cols();
+  const int width = layerOut.cols();
 
   for (int y = 0; y < height; y++) {
     for (int x = 0; x < width; x++) {

--- a/src/Nav/cprt_gridmap_filters/src/BoxBlurFilter.cpp
+++ b/src/Nav/cprt_gridmap_filters/src/BoxBlurFilter.cpp
@@ -18,7 +18,7 @@
 #include "grid_map_cv/utilities.hpp"
 
 namespace grid_map {
-//Error trapping for invalid parameters
+// Error trapping for invalid parameters
 template <typename T> BoxBlurFilter<T>::BoxBlurFilter() : radius_(0.0) {}
 
 template <typename T> BoxBlurFilter<T>::~BoxBlurFilter() {}
@@ -77,66 +77,70 @@ template <typename T> bool BoxBlurFilter<T>::update(const T &mapIn, T &mapOut) {
   mapOut.add(this->outputLayer_);
   mapOutHorz.add(this->outputLayer_);
 
-  HorizontalBoxBlur(mapIn[inputLayer_], mapOutHorz[outputLayer_], radius_); //Blurs input layer from mapIn horizontally, saves blurred values to mapOutHorz on outputLayer_
-  VerticalBoxBlur(mapOutHorz[outputLayer_], mapOut[outputLayer_], radius_); //Blurs outputLayer_ from mapOutHorz vertically, saves blurred values to mapOut on outputLayer_
-  //Box blur complete!
+  HorizontalBoxBlur(mapIn[inputLayer_], mapOutHorz[outputLayer_], radius_);
+  VerticalBoxBlur(mapOutHorz[outputLayer_], mapOut[outputLayer_], radius_);
   return true;
 }
 
 template <typename T>
-void BoxBlurFilter<T>::HorizontalBoxBlur(const Eigen::MatrixXf &layerIn, Eigen::MatrixXf &layerOut, int r) 
-{
+
+void BoxBlurFilter<T>::HorizontalBoxBlur(const Eigen::MatrixXf &layerIn,
+                                         Eigen::MatrixXf &layerOut, int r) {
   const int height = layerOut.rows();
   const int width = layerOut.cols();
 
   for (int y = 0; y < height; y++) {
     for (int x = 0; x < width; x++) {
-      //ensuring that max and min cells in radius do not exceed dimensions of gridmap layer
+      // ensuring that max and min cells in radius do not exceed dimensions of
+      // gridmap layer
       const int minCoeff = std::max(0, x - r);
       const int maxCoeff = std::min(width - 1, x + r);
-      int numHoles = 0;
+      int numValues = 0;
       double sum = 0;
 
       for (int i = minCoeff; i <= maxCoeff; i++) {
         const float value = layerIn(i, y);
-        if (!std::isfinite(value)) //checking for hole
+        if (!std::isfinite(value)) // checking for hole
         {
-          numHoles += 1; //if hole found, disregard it and continue
           continue;
         }
+        numValues++;
         sum += value;
       }
-      //calculate and write average to layerOut
+      // calculate and write average to layerOut
       if (numValues > 0) {
-        layerOut(x, y) = sum / numValues ;
+        layerOut(x, y) = sum / numValues;
       }
     }
   }
 }
 
 template <typename T>
-void BoxBlurFilter<T>::VerticalBoxBlur(const Eigen::MatrixXf &layerIn, Eigen::MatrixXf &layerOut, int r) 
-{
-  //Same algorithm as horizontal box blur, only along a column rather than a row
-  int height = layerOut.rows();
-  int width = layerOut.cols();
+void BoxBlurFilter<T>::VerticalBoxBlur(const Eigen::MatrixXf &layerIn,
+                                       Eigen::MatrixXf &layerOut, int r) {
+  const int height = layerOut.rows();
+  const int width = layerOut.cols();
 
   for (int x = 0; x < width; x++) {
     for (int y = 0; y < height; y++) {
-      int minCoeff = std::max(0, y - r);
-      int maxCoeff = std::min(height - 1, y + r);
-      int numHoles = 0;
+      const int minCoeff = std::max(0, y - r);
+      const int maxCoeff = std::min(height - 1, y + r);
+      int numValues = 0;
       double sum = 0;
 
       for (int i = minCoeff; i <= maxCoeff; i++) {
         const float value = layerIn(x, i);
-        if (!std::isfinite(value)) {
-          numHoles += 1;
+        if (!std::isfinite(value)) // checking for hole
+        {
           continue;
         }
+        numValues++;
         sum += value;
       }
-      layerOut(x, y) = sum / (maxCoeff - minCoeff + 1 - numHoles);
+      // calculate and write average to layerOut
+      if (numValues > 0) {
+        layerOut(x, y) = sum / numValues;
+      }
     }
   }
 }

--- a/src/Nav/cprt_gridmap_filters/src/BoxBlurFilter.cpp
+++ b/src/Nav/cprt_gridmap_filters/src/BoxBlurFilter.cpp
@@ -107,7 +107,9 @@ void BoxBlurFilter<T>::HorizontalBoxBlur(const Eigen::MatrixXf &layerIn, Eigen::
         sum += value;
       }
       //calculate and write average to layerOut
-      layerOut(x, y) = sum / (maxCoeff - minCoeff + 1 - numHoles);
+      if (numValues > 0) {
+        layerOut(x, y) = sum / numValues ;
+      }
     }
   }
 }

--- a/src/Nav/navigation/config/elevation_mapping/postprocessing_traversability.yaml
+++ b/src/Nav/navigation/config/elevation_mapping/postprocessing_traversability.yaml
@@ -37,14 +37,11 @@ elevation_mapping:
       ##### Option 2 - Boxblur computing empty cells #####
       filter3:
         name: boxblur
-        type: gridMapFilters/SlidingWindowMathExpressionFilter
+        type: cprtGridMapFilters/BoxBlurFilter
         params:
           input_layer: elevation
           output_layer: elevation_smooth
-          expression: meanOfFinites(elevation)
-          compute_empty_cells: true
-          edge_handling: crop # options: inside, crop, empty, mean
-          window_size: 3 # optional
+          radius: 1
 
       # Compute Surface normals
       filter4:


### PR DESCRIPTION
What:
Created a new box blur filter that can be applied to a gridmap layer to assist the rover in determining the traversability of terrain by smoothing over noise and holes. 

Why:
The built-in box blur function the rover had been using previously was inefficient, so this new algorithm was created with the intention of reducing latency. 

How:
This increased efficiency is achieved by using a separable algorithm in place of the naive implementation that was used previously. The gridmap layer inputLayer_ of mapIn is first blurred along the horizontal axis, and then blurred again, vertically before being returned in mapOut as outputLayer_. The function also takes in a blur radius (in units of cells, not distance), which is typically set to one but can be expanded.

Testing:
This code has been tested using the Jetson and the Zed camera, and the results have been compared against the old algorithm to find that they produce highly similar results (with the only differences being found along the edge of the map depending on what mode the old algorithm's edge handling was set to).

Other Notes:
Any potentially unclear lines _should_ be commented in the code, but do let me know if there's anything I need to clarify.
In the future, it would be possible to use weighted averages during the blurring process in order to achieve a Gaussian blur as opposed to a box blur (unweighted) were that to become necessary.