### PR TITLE
Add --parallel-workers and --packages-select to build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,37 @@
 #!/bin/bash
 
+# Ensure script is run from the workspace root
+if [ ! -d "src" ]; then
+    echo "Error: 'src' directory not found. This script must be run from the workspace root."
+    exit 1
+fi
+
+# Defaults
+PARALLEL_WORKERS=$(nproc)
+PACKAGES_SELECT=()
+
+# Argument parsing
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --parallel-workers)
+      PARALLEL_WORKERS="$2"
+      shift 2
+      ;;
+    --packages-select)
+      PACKAGES_SELECT=()
+      shift
+      while [[ $# -gt 0 ]] && ! [[ "$1" =~ ^-- ]]; do
+        PACKAGES_SELECT+=("$1")
+        shift
+      done
+      ;;
+    *)
+      echo "Unknown option: $1"
+      exit 1
+      ;;
+  esac
+done
+
 # Python format
 black . --exclude "src/third-party/|build|install|\.tox|dist"
 
@@ -10,4 +42,9 @@ find ./src -path ./src/third-party -prune -o \
 
 rosdep install --from-paths src -i -r -y
 
-colcon build --symlink-install --continue-on-error --cmake-args=-DCMAKE_BUILD_TYPE=Release --parallel-workers $(nproc)
+# Run colcon build based on whether specific packages were selected
+if [ ${#PACKAGES_SELECT[@]} -eq 0 ]; then
+    colcon build --symlink-install --continue-on-error --cmake-args=-DCMAKE_BUILD_TYPE=Release --parallel-workers $PARALLEL_WORKERS
+else
+    colcon build --symlink-install --continue-on-error --cmake-args=-DCMAKE_BUILD_TYPE=Release --parallel-workers $PARALLEL_WORKERS --packages-select "${PACKAGES_SELECT[@]}"
+fi

--- a/build.sh
+++ b/build.sh
@@ -13,14 +13,15 @@ PACKAGES_SELECT=()
 # Argument parsing
 while [[ $# -gt 0 ]]; do
   case $1 in
-    --parallel-workers)
+    -w|--parallel-workers)
       PARALLEL_WORKERS="$2"
       shift 2
       ;;
-    --packages-select)
+    -s|--packages-select)
       PACKAGES_SELECT=()
       shift
-      while [[ $# -gt 0 ]] && ! [[ "$1" =~ ^-- ]]; do
+      # Consumes args until the next flag (starts with -) or end of args
+      while [[ $# -gt 0 ]] && ! [[ "$1" =~ ^- ]]; do
         PACKAGES_SELECT+=("$1")
         shift
       done

--- a/build.sh
+++ b/build.sh
@@ -1,37 +1,25 @@
 #!/bin/bash
 
+# Check for help flag
+if [[ "$1" == "--help" ]] || [[ "$1" == "-h" ]]; then
+    echo "Usage: ./build.sh [colcon build options]"
+    echo ""
+    echo "This script formats code, installs dependencies, and builds the ROS2 workspace."
+    echo ""
+    echo "Examples:"
+    echo "  ./build.sh"
+    echo "  ./build.sh --parallel-workers 3"
+    echo "  ./build.sh --packages-select navigation localization gps bringup"
+    echo "  ./build.sh --packages-select navigation --parallel-workers 1"
+    echo ""
+    exit 0
+fi
+
 # Ensure script is run from the workspace root
 if [ ! -d "src" ]; then
     echo "Error: 'src' directory not found. This script must be run from the workspace root."
     exit 1
 fi
-
-# Defaults
-PARALLEL_WORKERS=$(nproc)
-PACKAGES_SELECT=()
-
-# Argument parsing
-while [[ $# -gt 0 ]]; do
-  case $1 in
-    -w|--parallel-workers)
-      PARALLEL_WORKERS="$2"
-      shift 2
-      ;;
-    -s|--packages-select)
-      PACKAGES_SELECT=()
-      shift
-      # Consumes args until the next flag (starts with -) or end of args
-      while [[ $# -gt 0 ]] && ! [[ "$1" =~ ^- ]]; do
-        PACKAGES_SELECT+=("$1")
-        shift
-      done
-      ;;
-    *)
-      echo "Unknown option: $1"
-      exit 1
-      ;;
-  esac
-done
 
 # Python format
 black . --exclude "src/third-party/|build|install|\.tox|dist"
@@ -43,9 +31,5 @@ find ./src -path ./src/third-party -prune -o \
 
 rosdep install --from-paths src -i -r -y
 
-# Run colcon build based on whether specific packages were selected
-if [ ${#PACKAGES_SELECT[@]} -eq 0 ]; then
-    colcon build --symlink-install --continue-on-error --cmake-args=-DCMAKE_BUILD_TYPE=Release --parallel-workers $PARALLEL_WORKERS
-else
-    colcon build --symlink-install --continue-on-error --cmake-args=-DCMAKE_BUILD_TYPE=Release --parallel-workers $PARALLEL_WORKERS --packages-select "${PACKAGES_SELECT[@]}"
-fi
+# Pass all arguments directly to colcon build with sensible defaults
+colcon build --symlink-install --continue-on-error --cmake-args=-DCMAKE_BUILD_TYPE=Release --parallel-workers "$(nproc)" "$@"


### PR DESCRIPTION
Finally got around to improving the build.sh so that it has a --parallel-workers option and a --packages-select option.

Can be used like this:
```bash
./build.sh
./build.sh --parallel-workers 2 # up to how many CPUs you have (check by running $ nproc)
./build.sh --packages-select navigation
./build.sh --packages-select navigation localization gps --parallel-workers 1
```
I intentionally used the same names as the colcon build arguments so that memorizing these arguments can translate over to the colcon build arguments. Buuuutttt I also just commited a -s for --packages-select and a -w for --parallel-workers because I dont like typing things out lol