### PR TITLE
feat: use onboard encoder + trapozoid trajectory

### DIFF
--- a/src/HW-Devices/ros_odrive/odrive_ros2_control/src/odrive_hardware_interface.cpp
+++ b/src/HW-Devices/ros_odrive/odrive_ros2_control/src/odrive_hardware_interface.cpp
@@ -341,6 +341,8 @@ void ODriveHardwareInterface::set_axis_command_mode(const Axis &axis) {
     RCLCPP_INFO(rclcpp::get_logger("ODriveHardwareInterface"),
                 "Setting to position control.");
     control_msg.Control_Mode = CONTROL_MODE_POSITION_CONTROL;
+    control_msg.Input_Mode =
+        INPUT_MODE_TRAP_TRAJ; // CPRT HACK: This should be configurable
   } else if (axis.vel_input_enabled_) {
     RCLCPP_INFO(rclcpp::get_logger("ODriveHardwareInterface"),
                 "Setting to velocity control.");

--- a/src/URDF/rover_urdf/urdf/chassis_urdf.ros2_control.xacro
+++ b/src/URDF/rover_urdf/urdf/chassis_urdf.ros2_control.xacro
@@ -38,24 +38,26 @@
       </joint>
 
       <joint name="Left_front_wheel_arm_joint">
-        <param name="node_id">1</param>
+        <param name="node_id">2</param>
+        <param name="multiplier">-0.0166666667</param>
         <command_interface name="position"/>
         <state_interface name="position"/>
       </joint>
       <joint name="Left_back_wheel_arm_joint">
         <param name="node_id">3</param>
+        <param name="multiplier">0.0166666667</param>
         <command_interface name="position"/>
         <state_interface name="position"/>
       </joint>
       <joint name="Right_front_wheel_arm_joint">
-        <param name="node_id">2</param>
-        <param name="multiplier">1.0</param>
+        <param name="node_id">1</param>
+        <param name="multiplier">0.0166666667</param>
         <command_interface name="position"/>
         <state_interface name="position"/>
       </joint>
       <joint name="Right_back_wheel_arm_joint">
         <param name="node_id">4</param>
-        <param name="multiplier">1.0</param>
+        <param name="multiplier">-0.0166666667</param>
         <command_interface name="position"/>
         <state_interface name="position"/>
       </joint>


### PR DESCRIPTION
Trap trajectory control from the odrive library is much easier on the motors. Ideally this is something that should be configureable but I am just going to make a Jira ticket for it and put it on the backlog. New members are always looking for easy non time sensitive tasks and this fits the bill.

Using a 60:1 scalling on the motors based on our gearbox(s). Also 2 of the signs needed to be flipped because of the direction of mounting.