### PR TITLE
Initial nav2 changes for swerve

### DIFF
--- a/src/Nav/cprt_costmap_plugins/src/gridmap_layer.cpp
+++ b/src/Nav/cprt_costmap_plugins/src/gridmap_layer.cpp
@@ -65,7 +65,7 @@ void GridmapLayer::getParameters() {
                    rclcpp::ParameterValue(true));
   declareParameter("transform_tolerance", rclcpp::ParameterValue(0.0));
   declareParameter("map_topic", rclcpp::ParameterValue("/map"));
-  declareParameter("layer_name", rclcpp::ParameterValue("trasversability_map"));
+  declareParameter("layer_name", rclcpp::ParameterValue("traversability_map"));
   declareParameter("footprint_clearing_enabled", rclcpp::ParameterValue(false));
 
   auto node = node_.lock();
@@ -84,7 +84,7 @@ void GridmapLayer::getParameters() {
   node->get_parameter("transform_tolerance", temp_tf_tol);
 
   // Enforce bounds
-  lethal_threshold_ = std::max(std::min(temp_lethal_threshold, 100), 0);
+  lethal_threshold_ = std::max(std::min(temp_lethal_threshold, 255), 0);
   map_received_ = false;
 
   transform_tolerance_ = tf2::durationFromSec(temp_tf_tol);

--- a/src/Nav/elevation_mapping/config/postprocessing/traversability_pipeline.yaml
+++ b/src/Nav/elevation_mapping/config/postprocessing/traversability_pipeline.yaml
@@ -1,7 +1,7 @@
 elevation_mapping:
   ros__parameters:
     # postprocessor_pipeline_name: traversability_postprocessing
-    output_topic: trasversability_map
+    output_topic: traversability_map
 
     postprocessor_pipeline:
 

--- a/src/Nav/elevation_mapping/rviz2/zed2i.rviz
+++ b/src/Nav/elevation_mapping/rviz2/zed2i.rviz
@@ -190,7 +190,7 @@ Visualization Manager:
         Filter size: 10
         History Policy: Keep Last
         Reliability Policy: Reliable
-        Value: /trasversability_map
+        Value: /traversability_map
       Use Rainbow: true
       Value: true
   Enabled: true

--- a/src/Nav/localization/config/rviz.views/basicNavMap.rviz
+++ b/src/Nav/localization/config/rviz.views/basicNavMap.rviz
@@ -70,7 +70,7 @@ Visualization Manager:
         Filter size: 10
         History Policy: Keep Last
         Reliability Policy: Reliable
-        Value: /trasversability_map
+        Value: /traversability_map
       Use Rainbow: true
       Value: true
     - Class: rviz_default_plugins/TF

--- a/src/Nav/navigation/2026_changes.md
+++ b/src/Nav/navigation/2026_changes.md
@@ -1,0 +1,185 @@
+# 2026 Nav2 Upgrade: Master Implementation Guide
+
+## Part 1: Implementation Checklist (Human)
+
+### 1. C++ Code Fixes (`cprt_costmap_plugins`)
+**Goal:** Fix the "Gradient Killer" bug and the "Diamond" rotation bug in your custom layer.
+
+- [ ] **Unclamp Lethal Threshold (Critical)**
+  Open `src/gridmap_layer.cpp`. Find `getParameters()`.
+  - **Change:** `lethal_threshold_ = std::max(std::min(temp_lethal_threshold, 100), 0);`
+  - **To:** `lethal_threshold_ = std::max(std::min(temp_lethal_threshold, 255), 0);`
+  - *Why:* The old clamp destroyed your smart gradients, turning everything >0.4 into a solid wall.
+
+- [ ] **Fix Bounding Box Rotation**
+  Open `src/gridmap_layer.cpp`. Replace the logic in `updateBounds()` to transform all 4 corners of the grid map.
+  - *Why:* The previous logic assumed the map was axis-aligned. When the robot turns 45°, the map becomes a diamond, and the old logic failed to clear the corners, leaving "ghost" obstacles.
+
+- [ ] **Rebuild Workspace**
+  Run: `colcon build --packages-select cprt_costmap_plugins`
+
+### 2. Launch File (`bringup.launch.py`)
+**Goal:** Fix fatal plugin crashes and ensure parameter consistency.
+
+- [ ] **Fix Plugin Class Name Typo**
+  In the `load_composable_nodes` list, find the `nav2_behaviors` entry.
+  - **Change:** `plugin="behavior_server::BehaviorServer"`
+  - **To:** `plugin="nav2_behaviors::BehaviorServer"`
+
+- [ ] **Fix Namespace Handling**
+  In the `load_nodes` group (standard nodes), add the namespace argument to ensure they read params correctly.
+  - **Action:** Add `namespace=namespace` to every `Node()` entry.
+
+### 3. Nav2 Configuration (`nav2.yaml`)
+**Goal:** Enable "Point Robot" logic, setup Swerve controller, and fix frequencies.
+
+#### A. Costmaps (The "Point Robot" Setup)
+*Context: We rely on upstream "Smart Inflation" (0.8m buffer), so Nav2 treats the robot as a point.*
+
+- [ ] **Global Costmap (Planner)**
+  - **Remove:** `footprint: "[[...]]"` and `plugins: [..., inflation_layer]`
+  - **Set:** `robot_radius: 0.2`
+    - *Why:* 0.8m (Upstream) + 0.2m (Nav2) = 1.0m Total Buffer. Safe planning.
+  - **Set:** `update_frequency: 10.0`
+    - *Why:* Synced with elevation map to prevent planning on stale data.
+
+- [ ] **Local Costmap (Controller)**
+  - **Remove:** `footprint: "[[...]]"` and `plugins: [..., inflation_layer]`
+  - **Set:** `robot_radius: 0.1`
+    - *Why:* 0.8m (Upstream) + 0.1m (Nav2) = 0.9m. Covers your 0.85m corner swing during rotations.
+  - **Set:** `update_frequency: 10.0`
+    - *Why:* Critical for fast collision checking on a moving rover.
+  - **Fix Typo:** Change topic from `/trasversability_map` to `/traversability_map`.
+
+#### B. Controller Server (Swerve Setup)
+*Context: Use Rotation Shim to force in-place turns before driving.*
+
+- [ ] **Enable Rotation Shim**
+  - **Change:** `controller_plugins: ["FollowPath"]`
+  - **Update `FollowPath` configuration:**
+    ```yaml
+    FollowPath:
+      plugin: "nav2_rotation_shim_controller::RotationShimController"
+      primary_controller: "nav2_regulated_pure_pursuit_controller::RegulatedPurePursuitController"
+      
+      # Shim Parameters (The Swerve Logic)
+      angular_dist_threshold: 0.5  # If path is >30 deg off, spin first
+      forward_sampling_distance: 0.5
+      rotate_to_heading_angular_vel: 1.0 
+      max_angular_accel: 2.0
+      simulate_ahead_time: 1.0
+
+      # RPP Parameters (The Driving Logic)
+      desired_linear_vel: 1.0 
+      lookahead_dist: 1.2
+      use_velocity_scaled_lookahead_dist: true
+      min_approach_linear_velocity: 0.05
+      use_rotate_to_heading: false # Disable this, let Shim handle it
+      allow_reversing: false       # Keep false as discussed
+    ```
+
+- [ ] **Tighten Goal Tolerance**
+  - In `general_goal_checker`: Set `xy_goal_tolerance: 0.5` (Swerve is precise enough for this).
+
+#### C. Planner Server (Smac Hybrid)
+*Context: Optimize for Swerve agility and High Precision.*
+
+- [ ] **Update GridBased Planner**
+  - **Set:** `minimum_turning_radius: 0.40` (Swerve can turn tighter than skid-steer).
+  - **Set:** `motion_model_for_search: "DUBIN"` (Forward-only; Shim handles turns).
+  - **Set:** `downsampling_factor: 1`
+    - *Why:* Downsampling "blurs" your precise upstream inflation. Factor 1 keeps the native 0.2m resolution so gaps stay open.
+
+#### D. Behavior Server
+- [ ] **Standardize Plugin Names**
+  - Update all plugins to use `::` format (e.g., `nav2_behaviors::Spin`) instead of `/`.
+
+### 4. Behavior Tree (`Maps.xml`)
+**Goal:** Implement the "Back Up & Spin" recovery for forward-only planning.
+
+- [ ] **Replace `RecoveryFallback` Block**
+  Replace the bottom `<ReactiveFallback name="RecoveryFallback">` section with:
+  ```xml
+  <ReactiveFallback name="RecoveryFallback">
+    <GoalUpdated/>
+    <RoundRobin name="RecoveryActions">
+      
+      <Sequence name="ClearLocalSeq">
+        <ClearEntireCostmap name="ClearLocalCostmap-Subtree" service_name="local_costmap/clear_entirely_local_costmap"/>
+        <Wait wait_duration="1.0"/>
+      </Sequence>
+
+      <Sequence name="BackupSeq">
+        <BackUp backup_dist="0.30" backup_speed="0.05"/>
+        <Wait wait_duration="0.5"/>
+      </Sequence>
+
+      <Sequence name="SpinSeq">
+        <Spin spin_dist="3.14" time_allowance="5.0"/> 
+        <Wait wait_duration="1.0"/>
+      </Sequence>
+
+      <ClearEntireCostmap name="ClearGlobalCostmap-Subtree" service_name="global_costmap/clear_entirely_global_costmap"/>
+
+    </RoundRobin>
+  </ReactiveFallback>
+
+
+# Context: Project Rover Navigation Upgrade (2025 -> 2026)
+
+This document outlines the architectural changes, hardware upgrades, and design constraints for the rover's autonomous navigation stack. Use this context to understand why specific changes are being applied to the `nav2.yaml`, launch files, and behavior trees.
+
+## 1. Hardware Evolution
+* **Previous Platform (2025):**
+    * **Chassis:** High-friction Skid-Steer.
+    * **Issues:** Inability to point turn reliably, high friction causing stalling on tight turns, required wide planning radii (`min_turning_radius: 0.8`), and frequently got stuck.
+* **Current Platform (2026):**
+    * **Chassis:** 4-Wheel Independent Swerve Drive.
+    * **Capabilities:** Full -90° to +90° steering on each wheel. Capable of efficient "Ackermann-style" driving and zero-radius point turns.
+    * **Dimensions:** 1.2m x 1.2m (Square).
+    * **Sensors:** Front-facing camera, Lidar, RTK GPS (0.2m accuracy).
+
+## 2. Navigation Architecture Strategy
+We use a specialized pipeline that differs from standard Nav2 setups:
+* **Global Planning:** Custom "Event Horizon Planner" (handles long-range goals >300m) feeding into `SmacPlannerHybrid` (handles kinematic feasibility).
+* **Mapping:** Custom `PreserveCostInflationFilter` upstream.
+    * *Crucial Detail:* We inflate obstacles *upstream* in the elevation map before Nav2 sees them.
+    * *Current Setting:* `coreInflationRadius: 0.8m`. This builds a "Lethal" wall 0.8m around every obstacle.
+* **Localization:** EKF fusing IMU, Wheel Encoders, and RTK GPS data.
+
+## 3. Key Configuration Decisions & Rationale
+
+### A. The "Point Robot" Configuration (Costmaps)
+**Change:** Removed `footprint` polygon; set `robot_radius` to small values (0.2m Global, 0.1m Local).
+**Why:**
+* Since obstacles are already inflated by 0.8m upstream, defining a full footprint in Nav2 results in "Double Inflation" (1.3m+ buffer), making valid gaps appear impassable.
+* **Logic:**
+    * **Planner Safety:** Upstream (0.8m) + Nav2 Global Radius (0.2m) = **1.0m Total Buffer**. (Safe planning).
+    * **Controller Limit:** Upstream (0.8m) + Nav2 Local Radius (0.1m) = **0.9m Total Buffer**. (Prevents corners clipping during rotation, since circumscribed radius is ~0.85m).
+
+### B. Swerve Controller Setup
+**Change:** Switched to `RegulatedPurePursuit` wrapped in `RotationShimController`.
+**Why:**
+* The `SmacPlannerHybrid` is configured for **Dubin (Forward-Only)** paths to prevent dangerous reversing with only a front camera.
+* The **Rotation Shim** detects when the planner requests a sharp turn (which the Dubin planner allows due to the "Point Robot" config) and automatically **Point Turns** the swerve drive to face the path before driving.
+* This mimics "Force Point Turn" behavior without needing a separate planner.
+
+### C. Launch File Fixes
+**Change:**
+1.  Fixed `nav2_behaviors` plugin namespace typo (Critical crash fix).
+2.  Added `namespace` argument to all standard `Node` entries.
+**Why:**
+* Prevents runtime crashes when Composition is enabled.
+* Ensures parameter overrides (like `use_sim_time`) propagate correctly to non-composed nodes.
+
+### D. Recovery Behavior (Forward-Only)
+**Change:** Updated Behavior Tree `RecoveryFallback` to "Backup (0.3m) -> Spin (180°)".
+**Why:**
+* The planner is configured as forward-only (Dubin). If the robot faces a dead end, the planner fails.
+* Backing up slightly un-wedges the robot.
+* Spinning 180° mechanically puts the empty space *in front* of the sensors and planner, allowing the forward-only logic to find a valid exit path.
+
+## 4. Constraints for Future Code Generation
+* **Do not re-enable Nav2 Inflation Layer:** We rely on the upstream `PreserveCostInflationFilter`.
+* **Do not increase Update Frequencies arbitrarily:** Global costmap runs at ~2Hz (sufficient for static terrain), but Local Costmap MUST run at ~10Hz+ for collision safety.
+* **Do not enable reversing:** Blind spots behind the rover make automatic reversing dangerous.

--- a/src/Nav/navigation/behavior_trees/bt_swerve_dynamic_replanning.xml
+++ b/src/Nav/navigation/behavior_trees/bt_swerve_dynamic_replanning.xml
@@ -1,0 +1,57 @@
+<!--
+  This Behavior Tree replans the global path once every 15 seconds or if the path becomes invalid. It also has
+  recovery actions specific to planning / control as well as general system issues.
+  This will be continuous if a kinematically valid planner is selected.
+-->
+<root main_tree_to_execute="MainTree">
+  <BehaviorTree ID="MainTree">
+    <RecoveryNode number_of_retries="6" name="NavigateRecovery">
+      <PipelineSequence name="NavigateWithReplanning">
+        <RateController hz="2.0">
+          <RecoveryNode number_of_retries="1" name="ComputePathToPose">
+            <Fallback>
+              <ReactiveSequence>
+                <Inverter>
+                  <PathExpiringTimer seconds="15" path="{path}"/>
+                </Inverter>
+                <Inverter>
+                  <GlobalUpdatedGoal/>
+                </Inverter>
+                <IsPathValid path="{path}"/>
+              </ReactiveSequence>
+              <ComputePathToPose goal="{goal}" path="{path}" planner_id="GridBased"/>
+            </Fallback>
+            <ClearEntireCostmap name="ClearGlobalCostmap-Context" service_name="global_costmap/clear_entirely_global_costmap"/>
+          </RecoveryNode>
+        </RateController>
+        <RecoveryNode number_of_retries="1" name="FollowPath">
+          <FollowPath path="{path}" controller_id="FollowPath"/>
+          <ClearEntireCostmap name="ClearLocalCostmap-Context" service_name="local_costmap/clear_entirely_local_costmap"/>
+        </RecoveryNode>
+      </PipelineSequence>
+      <ReactiveFallback name="RecoveryFallback">
+        <GoalUpdated/>
+        <RoundRobin name="RecoveryActions">
+          
+          <Sequence name="ClearLocalSeq">
+            <ClearEntireCostmap name="ClearLocalCostmap-Subtree" service_name="local_costmap/clear_entirely_local_costmap"/>
+            <Wait wait_duration="1.0"/>
+          </Sequence>
+
+          <Sequence name="BackupSeq">
+            <BackUp backup_dist="0.30" backup_speed="0.05"/>
+            <Wait wait_duration="0.5"/>
+          </Sequence>
+
+          <Sequence name="SpinSeq">
+            <Spin spin_dist="3.14" time_allowance="5.0"/>
+            <Wait wait_duration="1.0"/>
+          </Sequence>
+
+          <ClearEntireCostmap name="ClearGlobalCostmap-Subtree" service_name="global_costmap/clear_entirely_global_costmap"/>
+
+        </RoundRobin>
+      </ReactiveFallback>
+    </RecoveryNode>
+  </BehaviorTree>
+</root>

--- a/src/Nav/navigation/config/elevation_mapping/postprocessing_traversability.yaml
+++ b/src/Nav/navigation/config/elevation_mapping/postprocessing_traversability.yaml
@@ -1,7 +1,7 @@
 elevation_mapping:
   ros__parameters:
     # postprocessor_pipeline_name: traversability_postprocessing
-    output_topic: trasversability_map
+    output_topic: traversability_map
 
     postprocessor_pipeline:
       filter1:

--- a/src/Nav/navigation/launch/nav2.launch.py
+++ b/src/Nav/navigation/launch/nav2.launch.py
@@ -28,7 +28,7 @@ from nav2_common.launch import RewrittenYaml
 
 def generate_launch_description():
     # Constants
-    DEFAULT_BT_XML_FILENAME = "bt_dynamic_replanning.xml"
+    DEFAULT_BT_XML_FILENAME = "bt_swerve_dynamic_replanning.xml"
 
     # Get the launch directory
     pkg_dir = get_package_share_directory("navigation")
@@ -152,6 +152,7 @@ def generate_launch_description():
                 package="nav2_controller",
                 executable="controller_server",
                 output="screen",
+                namespace=namespace,
                 respawn=use_respawn,
                 respawn_delay=2.0,
                 parameters=[configured_params],
@@ -162,6 +163,7 @@ def generate_launch_description():
                 executable="smoother_server",
                 name="smoother_server",
                 output="screen",
+                namespace=namespace,
                 respawn=use_respawn,
                 respawn_delay=2.0,
                 parameters=[configured_params],
@@ -172,6 +174,7 @@ def generate_launch_description():
                 executable="planner_server",
                 name="planner_server",
                 output="screen",
+                namespace=namespace,
                 respawn=use_respawn,
                 respawn_delay=2.0,
                 parameters=[configured_params],
@@ -182,6 +185,7 @@ def generate_launch_description():
                 executable="behavior_server",
                 name="behavior_server",
                 output="screen",
+                namespace=namespace,
                 respawn=use_respawn,
                 respawn_delay=2.0,
                 parameters=[configured_params],
@@ -192,6 +196,7 @@ def generate_launch_description():
                 executable="bt_navigator",
                 name="bt_navigator",
                 output="screen",
+                namespace=namespace,
                 respawn=use_respawn,
                 respawn_delay=2.0,
                 parameters=[configured_params],
@@ -202,6 +207,7 @@ def generate_launch_description():
                 executable="waypoint_follower",
                 name="waypoint_follower",
                 output="screen",
+                namespace=namespace,
                 respawn=use_respawn,
                 respawn_delay=2.0,
                 parameters=[configured_params],
@@ -212,6 +218,7 @@ def generate_launch_description():
                 executable="lifecycle_manager",
                 name="lifecycle_manager_navigation",
                 output="screen",
+                namespace=namespace,
                 parameters=[
                     {"use_sim_time": use_sim_time},
                     {"autostart": autostart},
@@ -224,6 +231,7 @@ def generate_launch_description():
                 executable="velocity_smoother",
                 name="velocity_smoother",
                 output="screen",
+                namespace=namespace,
                 respawn=use_respawn,
                 respawn_delay=2.0,
                 parameters=[configured_params],

--- a/src/Nav/navigation/params/nav2.yaml
+++ b/src/Nav/navigation/params/nav2.yaml
@@ -231,9 +231,6 @@ controller_server:
       regulated_linear_scaling_min_radius: 0.9
       regulated_linear_scaling_min_speed: 0.25
 
-      use_rotate_to_heading: false
-      max_angular_accel: 0.5
-
       use_interpolation: false
       cost_scaling_dist: 0.5
       cost_scaling_gain: 1.0

--- a/src/Nav/navigation/params/nav2.yaml
+++ b/src/Nav/navigation/params/nav2.yaml
@@ -211,6 +211,8 @@ controller_server:
       max_angular_accel: 2.0              # Max angular acceleration
       simulate_ahead_time: 1.0            # Simulation time for collision checking
 
+      use_rotate_to_heading: false # Disable since using rotation shim controller
+
       # Regulated Pure Pursuit Parameters (Driving Logic)
       transform_tolerance: 1.0
 

--- a/src/Nav/navigation/params/nav2.yaml
+++ b/src/Nav/navigation/params/nav2.yaml
@@ -65,8 +65,8 @@ bt_navigator_navigate_to_pose_rclcpp_node:
 local_costmap:
   local_costmap:
     ros__parameters:
-      update_frequency: 1.0
-      publish_frequency: 1.0
+      update_frequency: 10.0
+      publish_frequency: 2.0
       global_frame: odom
       robot_base_frame: base_link
       use_sim_time: True
@@ -77,19 +77,19 @@ local_costmap:
       width: 5
       height: 5
       resolution: 0.2
-      footprint: "[[0.56, 0.48], [0.56, -0.48], [-0.56, -0.48], [-0.56, 0.48]]"
+      robot_radius: 0.1
       plugins: [obstacle_layer]
       obstacle_layer:
         plugin: "cprt_costmap_plugins::GridmapLayer"
         enabled: true
-        map_topic: "/trasversability_map"
+        map_topic: "/traversability_map"
         layer_name: "traversability"
       always_send_full_costmap: true
 
 global_costmap:
   global_costmap:
     ros__parameters:
-      update_frequency: 2.0
+      update_frequency: 10.0
       publish_frequency: 0.5
       global_frame: map
       robot_base_frame: base_link
@@ -99,30 +99,17 @@ global_costmap:
       origin_x: -50.0
       origin_y: -50.0
       use_sim_time: True
-      footprint: "[[0.55, 0.45], [0.55, -0.45], [-0.55, -0.45], [-0.55, 0.45]]"
+      robot_radius: 0.3
       resolution: 0.2
       track_unknown_space: true
       trinary_costmap: false
       lethal_cost_threshold: 200
       unknown_cost_value: 255 # 255 is special key for unknown value
-      # plugins: [static_layer, inflation_layer, obstacle_layer]
       plugins: [obstacle_layer]
-      # plugins: [static_layer, inflation_layer]
-      # static_layer: 
-      #   enabled: true
-      #   plugin: nav2_costmap_2d::StaticLayer
-      #   map_subscribe_transient_local: True
-      #   subscribe_to_updates: True
-      #   footprint_clearing_enabled: True
-      #   map_topic: /map
-      inflation_layer:
-        plugin: nav2_costmap_2d::InflationLayer
-        cost_scaling_factor: 3.0
-        inflation_radius: 1.0
       obstacle_layer:
         plugin: "cprt_costmap_plugins::GridmapLayer"
         enabled: true
-        map_topic: "/trasversability_map"
+        map_topic: "/traversability_map"
         layer_name: "inflated_traversability"
       always_send_full_costmap: True
 
@@ -143,8 +130,8 @@ planner_server:
       horizon_distance: 40.0              # distance from start pose for which an intermediate goal should be created by EventHorizonPlanner
       intermediate_tolerance: 10.0        # tolerance value for intermediate goal created by EventHorizonPlanner
 
-      downsample_costmap: true            # whether or not to downsample the map
-      downsampling_factor: 2              # multiplier for the resolution of the costmap layer (e.g. 2 on a 5cm costmap would be 10cm)
+      downsample_costmap: false            # whether or not to downsample the map
+      downsampling_factor: 1              # multiplier for the resolution of the costmap layer (e.g. 2 on a 5cm costmap would be 10cm)
       tolerance: 0.5                      # dist-to-goal heuristic cost (distance) for valid tolerance endpoints if exact goal cannot be found.
       allow_unknown: true                 # allow traveling in unknown space
       goal_heading_mode: "ALL_DIRECTION"  # For “ALL_DIRECTION” mode, the planner will plan the goal with the orientation of the goal pose and all the possible orientation based on the angle quantization bins
@@ -158,7 +145,7 @@ planner_server:
       analytic_expansion_max_length: 3.0  # For Hybrid/Lattice nodes: The maximum length of the analytic expansion to be considered valid to prevent unsafe shortcutting
       analytic_expansion_max_cost: 200.0  # The maximum single cost for any part of an analytic expansion to contain and be valid, except when necessary on approach to goal
       analytic_expansion_max_cost_override: false  #  Whether or not to override the maximum cost setting if within critical distance to goal (ie probably required)
-      minimum_turning_radius: 0.80        # minimum turning radius in m of path / vehicle
+      minimum_turning_radius: 0.40        # minimum turning radius in m of path / vehicle (Swerve can turn tighter)
       reverse_penalty: 2.0                # Penalty to apply if motion is reversing, must be => 1
       change_penalty: 0.0                 # Penalty to apply if motion is changing directions (L to R), must be >= 0
       non_straight_penalty: 1.2           # Penalty to apply if motion is non-straight, must be => 1
@@ -210,24 +197,33 @@ controller_server:
     general_goal_checker:
       stateful: True
       plugin: nav2_controller::SimpleGoalChecker
-      xy_goal_tolerance: 1.1
-      yaw_goal_tolerance: 5.0
+      xy_goal_tolerance: 0.5 
+      yaw_goal_tolerance: 0.2 # ~11 degrees
 
     FollowPath:
-      plugin: nav2_regulated_pure_pursuit_controller::RegulatedPurePursuitController
+      plugin: nav2_rotation_shim_controller::RotationShimController
+      primary_controller: nav2_regulated_pure_pursuit_controller::RegulatedPurePursuitController
+      
+      # Rotation Shim Parameters (Swerve Logic - Point Turn Before Driving)
+      angular_dist_threshold: 0.5         # If path angle > 30deg, rotate in place first
+      forward_sampling_distance: 0.5      # How far ahead to check path orientation
+      rotate_to_heading_angular_vel: 1.0  # Angular velocity during point turn
+      max_angular_accel: 2.0              # Max angular acceleration
+      simulate_ahead_time: 1.0            # Simulation time for collision checking
 
+      # Regulated Pure Pursuit Parameters (Driving Logic)
       transform_tolerance: 1.0
 
-      desired_linear_vel: 0.5
+      desired_linear_vel: 0.3 # Increase to 1.0 for outdoor swerve agility
       max_robot_pose_search_dist: 10.0
 
-      lookahead_dist: 1.0
+      lookahead_dist: 1.2
       min_lookahead_dist: 0.3
-      max_lookahead_dist: 1.0
+      max_lookahead_dist: 1.5
       lookahead_time: 1.5
-      use_velocity_scaled_lookahead_dist: false
+      use_velocity_scaled_lookahead_dist: true
 
-      min_approach_linear_velocity: 0.1
+      min_approach_linear_velocity: 0.05
       max_allowed_time_to_collision_up_to_carrot: 5.0
 
       use_regulated_linear_velocity_scaling: false
@@ -236,8 +232,6 @@ controller_server:
       regulated_linear_scaling_min_speed: 0.25
 
       use_rotate_to_heading: false
-      # rotate_to_heading_min_angle: 0.8
-      # rotate_to_heading_angular_vel: 1.0
       max_angular_accel: 0.5
 
       use_interpolation: false
@@ -254,13 +248,13 @@ behavior_server:
     cycle_frequency: 0.4
     behavior_plugins: [spin, backup, drive_on_heading, wait]
     spin:
-      plugin: nav2_behaviors/Spin
+      plugin: nav2_behaviors::Spin
     backup:
-      plugin: nav2_behaviors/BackUp
+      plugin: nav2_behaviors::BackUp
     drive_on_heading:
-      plugin: nav2_behaviors/DriveOnHeading
+      plugin: nav2_behaviors::DriveOnHeading
     wait:
-      plugin: nav2_behaviors/Wait
+      plugin: nav2_behaviors::Wait
     global_frame: odom
     robot_base_frame: base_link
     transform_tolerance: 0.1
@@ -291,11 +285,19 @@ velocity_smoother:
     smoothing_frequency: 20.0
     scale_velocities: False
     feedback: OPEN_LOOP
-    max_velocity: [1.0, 0.0, 2.0]
-    min_velocity: [-1.0, 0.0, -2.0]
-    max_accel: [0.1, 0.0, 1.0]
-    max_decel: [-0.1, 0.0, -1.0]
     odom_topic: odometry/filtered/local
     odom_duration: 0.1
     deadband_velocity: [0.0, 0.0, 0.0]
     velocity_timeout: 1.0
+    # OUTDOOR SWERVE
+    # max_velocity: [1.5, 0.0, 2.0]    # [x, y, theta] in m/s, m/s, rad/s
+    # min_velocity: [-1.5, 0.0, -2.0]
+    # max_accel: [0.5, 0.0, 1.5]       # [x, y, theta] in m/s², m/s², rad/s²
+    # max_decel: [-0.5, 0.0, -1.5]
+    # INDOOR TESTING 
+    # Safe limits for initial testing in confined spaces
+    max_velocity: [0.3, 0.0, 0.5]      # [x, y, theta] in m/s, m/s, rad/s
+    min_velocity: [-0.3, 0.0, -0.5]
+    max_accel: [0.2, 0.0, 0.5]         # [x, y, theta] in m/s², m/s², rad/s²
+    max_decel: [-0.2, 0.0, -0.5]
+    

--- a/src/Nav/navigation/params/nav2.yaml
+++ b/src/Nav/navigation/params/nav2.yaml
@@ -7,10 +7,7 @@ bt_navigator:
     bt_loop_duration: 10
     default_server_timeout: 20
     # default_nav_through_poses_bt_xml: ""
-    default_nav_to_pose_bt_xml: ""
-    # nav2_bt_navigator/navigate_to_pose_w_replanning_and_recovery.xml
-    # nav2_bt_navigator/navigate_through_poses_w_replanning_and_recovery.xml
-    # They can be set here or via a RewrittenYaml remap from a parent launch file to Nav2.
+    default_nav_to_pose_bt_xml: "" # Rewritten by launch file
     plugin_lib_names:
       - nav2_compute_path_to_pose_action_bt_node
       - nav2_compute_path_through_poses_action_bt_node
@@ -64,64 +61,6 @@ bt_navigator_navigate_through_poses_rclcpp_node:
 bt_navigator_navigate_to_pose_rclcpp_node:
   ros__parameters:
     use_sim_time: True
-
-controller_server:
-  ros__parameters:
-    use_sim_time: True
-    odom_topic: odometry/filtered/local
-    controller_frequency: 20.0
-    min_x_velocity_threshold: 0.1
-    min_y_velocity_threshold: 0.0
-    min_theta_velocity_threshold: 0.1
-    progress_checker_plugin: progress_checker
-    goal_checker_plugins: [general_goal_checker]
-    controller_plugins: [FollowPath]
-
-    progress_checker:
-      plugin: nav2_controller::SimpleProgressChecker
-      required_movement_radius: 0.5
-      movement_time_allowance: 10.0
-
-    general_goal_checker:
-      stateful: True
-      plugin: nav2_controller::SimpleGoalChecker
-      xy_goal_tolerance: 1.1
-      yaw_goal_tolerance: 5.0
-
-    FollowPath:
-      plugin: nav2_regulated_pure_pursuit_controller::RegulatedPurePursuitController
-
-      transform_tolerance: 1.0
-
-      desired_linear_vel: 0.5
-      max_robot_pose_search_dist: 10.0
-
-      lookahead_dist: 1.0
-      min_lookahead_dist: 0.3
-      max_lookahead_dist: 1.0
-      lookahead_time: 1.5
-      use_velocity_scaled_lookahead_dist: false
-
-      min_approach_linear_velocity: 0.1
-      max_allowed_time_to_collision_up_to_carrot: 5.0
-
-      use_regulated_linear_velocity_scaling: false
-      use_cost_regulated_linear_velocity_scaling: false
-      regulated_linear_scaling_min_radius: 0.9
-      regulated_linear_scaling_min_speed: 0.25
-
-      use_rotate_to_heading: false
-      # rotate_to_heading_min_angle: 0.8
-      # rotate_to_heading_angular_vel: 1.0
-      max_angular_accel: 0.5
-
-      use_interpolation: false
-      cost_scaling_dist: 0.5
-      cost_scaling_gain: 1.0
-      inflation_cost_scaling_factor: 10.0
-
-      allow_reversing: false
-
 
 local_costmap:
   local_costmap:
@@ -187,18 +126,6 @@ global_costmap:
         layer_name: "inflated_traversability"
       always_send_full_costmap: True
 
-map_server:
-  ros__parameters:
-    use_sim_time: True
-    yaml_filename: turtlebot3_world.yaml
-
-map_saver:
-  ros__parameters:
-    use_sim_time: True
-    save_map_timeout: 5.0
-    free_thresh_default: 0.25
-    occupied_thresh_default: 0.65
-    map_subscribe_transient_local: True
 
 planner_server:
   ros__parameters:
@@ -262,6 +189,63 @@ smoother_server:
       tolerance: 1.0e-10
       max_its: 1000
       do_refinement: True
+
+controller_server:
+  ros__parameters:
+    use_sim_time: True
+    odom_topic: odometry/filtered/local
+    controller_frequency: 20.0
+    min_x_velocity_threshold: 0.1
+    min_y_velocity_threshold: 0.0
+    min_theta_velocity_threshold: 0.1
+    progress_checker_plugin: progress_checker
+    goal_checker_plugins: [general_goal_checker]
+    controller_plugins: [FollowPath]
+
+    progress_checker:
+      plugin: nav2_controller::SimpleProgressChecker
+      required_movement_radius: 0.5
+      movement_time_allowance: 10.0
+
+    general_goal_checker:
+      stateful: True
+      plugin: nav2_controller::SimpleGoalChecker
+      xy_goal_tolerance: 1.1
+      yaw_goal_tolerance: 5.0
+
+    FollowPath:
+      plugin: nav2_regulated_pure_pursuit_controller::RegulatedPurePursuitController
+
+      transform_tolerance: 1.0
+
+      desired_linear_vel: 0.5
+      max_robot_pose_search_dist: 10.0
+
+      lookahead_dist: 1.0
+      min_lookahead_dist: 0.3
+      max_lookahead_dist: 1.0
+      lookahead_time: 1.5
+      use_velocity_scaled_lookahead_dist: false
+
+      min_approach_linear_velocity: 0.1
+      max_allowed_time_to_collision_up_to_carrot: 5.0
+
+      use_regulated_linear_velocity_scaling: false
+      use_cost_regulated_linear_velocity_scaling: false
+      regulated_linear_scaling_min_radius: 0.9
+      regulated_linear_scaling_min_speed: 0.25
+
+      use_rotate_to_heading: false
+      # rotate_to_heading_min_angle: 0.8
+      # rotate_to_heading_angular_vel: 1.0
+      max_angular_accel: 0.5
+
+      use_interpolation: false
+      cost_scaling_dist: 0.5
+      cost_scaling_gain: 1.0
+      inflation_cost_scaling_factor: 10.0
+
+      allow_reversing: false
 
 behavior_server:
   ros__parameters:


### PR DESCRIPTION
Made a few changes to improve nav2 for the better chassis.

Some notable things:
- fixed bug in `cprt_costmap_plugins::GridmapLayer` that was clamping our 200 lethal cost threshold to 100
- Replaced costmap footprint with a tiny robot_radius since the planner and controller should be driving like an infinitely small point because its handled by elevation mapping inflation filter.
- Set global costmap robot_radius to 0.2 meters more than local costmap so the planner goes farther away than the collision checking to avoid getting stuck
- Increased update frequency of costmaps so its more update to date when its used
- Rotation shim controller
- Tighter turning radius
- New recovery in bt: backup 0.3 meters then spin 180 degrees

This commit is easier to read the changes since I moved the order of some configs in nav2.yaml first: https://github.com/CPRT/rover/pull/64/changes/c02fbd2b060cda327bfc1baed940960e2763d88f