### PR TITLE
Camera fixes

### DIFF
--- a/src/Cameras/video_streaming/config/cameras.yaml
+++ b/src/Cameras/video_streaming/config/cameras.yaml
@@ -6,6 +6,7 @@ input_node:
     - "Drive"
     - "EndEffector"
     - "Bottom"
+    - "Mast"
     - "Test"
     Drive:
       path: "/dev/v4l/by-id/drive_camera"
@@ -24,5 +25,11 @@ input_node:
       encoded: true
       height: 480
       width: 640
+    Mast:
+      path: "/dev/v4l/by-id/usb-Sonix_Technology_Co.__Ltd._Webcam_Webcam-video-index0"
+      type: 0
+      encoded: true
+      height: 720
+      width: 1280
     Test:
       type: 1

--- a/src/Cameras/video_streaming/launch/video_streaming.launch.py
+++ b/src/Cameras/video_streaming/launch/video_streaming.launch.py
@@ -38,7 +38,7 @@ def generate_launch_description():
         plugin="video_streaming::RtpNode",
         name="rtp_node",
         namespace="",
-        parameters=[{"dest_ip": "192.168.0.20", "dest_port": 5004}],
+        parameters=[{"dest_ip": "192.168.0.20", "dest_port": 5004, "bitrate": 500000}],
     )
 
     capture_node = ComposableNode(


### PR DESCRIPTION
Starts the video streaming at a really low bitrate. During start up the packet storms are bad enough - lets make sure we start with as much bandwidth availible as possible.

Also adds the mast cam