### PR TITLE
chore: use cuda 13.3 version

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=nvidia/cuda:13.2.1-cudnn-runtime-ubuntu24.04
+ARG BASE_IMAGE=nvidia/cuda:13.3.0-cudnn-runtime-ubuntu24.04
 FROM ${BASE_IMAGE} AS base
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # Load config
 IMAGE_NAME="cprtsoftware/rover"
-BASE_IMAGE=nvidia/cuda:13.2.1-cudnn-runtime-ubuntu24.04
+BASE_IMAGE=nvidia/cuda:13.3.0-cudnn-runtime-ubuntu24.04
 GIT_SHA=$(git rev-parse HEAD)
 
 # Default settings


### PR DESCRIPTION
To get around this big: https://forums.developer.nvidia.com/t/cuda-13-2-1-runtime-image-cant-run-on-r39-2-sample-rootfs-for-orin-nano/372683