### PR TITLE
Video stream mosaic

### DIFF
--- a/src/Cameras/video_streaming/CMakeLists.txt
+++ b/src/Cameras/video_streaming/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(${PROJECT_NAME} SHARED
   src/input_node.cpp
   src/detect_node.cpp
   src/webrtc_node.cpp
+  src/mosaic_webrtc_node.cpp
   src/srt_node.cpp
   src/srt_node_client.cpp
   src/rtp_node.cpp
@@ -71,6 +72,7 @@ rclcpp_components_register_nodes(${PROJECT_NAME}
   "InputNode"
   "DetectNode"
   "WebRtcNode"
+  "video_streaming::MosaicWebRtcNode"
   "VideoCaptureNode"
   "video_streaming::SrtNode"
   "video_streaming::SrtClientNode"

--- a/src/Cameras/video_streaming/include/video_streaming/input_node.hpp
+++ b/src/Cameras/video_streaming/include/video_streaming/input_node.hpp
@@ -18,15 +18,12 @@ protected:
   bool create_pipeline() override;
   void declare_parameters();
 
-  /**
-   * @brief Callback function to configure the video feed.
-   *
-   * @param request The request object containing video output parameters.
-   * @param response The response object to be populated with the result.
-   */
   void
   video_cb(const std::shared_ptr<interfaces::srv::VideoOut::Request> request,
            std::shared_ptr<interfaces::srv::VideoOut::Response> response);
+
+  // Apply fixed grid layout to the mosaic compositor after pipeline creation.
+  bool set_mosaic_layout();
 
 private:
   std::map<std::string, size_t> source_map_;

--- a/src/Cameras/video_streaming/include/video_streaming/mosaic_webrtc_node.hpp
+++ b/src/Cameras/video_streaming/include/video_streaming/mosaic_webrtc_node.hpp
@@ -1,0 +1,16 @@
+#pragma once
+#include "base_video_node.hpp"
+
+namespace video_streaming {
+
+class MosaicWebRtcNode : public BaseVideoNode {
+public:
+  explicit MosaicWebRtcNode(
+      const rclcpp::NodeOptions &options = rclcpp::NodeOptions());
+  ~MosaicWebRtcNode() override = default;
+
+protected:
+  bool create_pipeline() override;
+};
+
+} // namespace video_streaming

--- a/src/Cameras/video_streaming/launch/video_streaming.launch.py
+++ b/src/Cameras/video_streaming/launch/video_streaming.launch.py
@@ -49,7 +49,16 @@ def generate_launch_description():
         parameters=[camera_params_file],
     )
 
-    # Create a container for all 3 components
+    # Streams the mosaic compositor output via WebRTC on a separate signalling
+    # server (default port 8444) so the WebUI mosaic tile can connect to it.
+    mosaic_webrtc_node = ComposableNode(
+        package="video_streaming",
+        plugin="video_streaming::MosaicWebRtcNode",
+        name="mosaic_webrtc_node",
+        namespace="",
+        parameters=[{"signalling_port": 8444, "bitrate": 1000000, "framerate": 5}],
+    )
+
     container = ComposableNodeContainer(
         name="video_streaming_container",
         namespace="",
@@ -60,6 +69,7 @@ def generate_launch_description():
             detect_node,
             capture_node,
             rtp_node,
+            mosaic_webrtc_node,
         ],
         output="screen",
     )

--- a/src/Cameras/video_streaming/src/input_node.cpp
+++ b/src/Cameras/video_streaming/src/input_node.cpp
@@ -1,4 +1,5 @@
 #include "input_node.hpp"
+#include <cmath>
 #include <filesystem>
 #include <rclcpp_components/register_node_macro.hpp>
 
@@ -39,14 +40,20 @@ void InputNode::declare_parameters() {
 }
 
 bool InputNode::create_pipeline() {
-  std::stringstream desc_stream;
-  // Hack: Use a constant videotestsrc for the sink_0 to ensure the compositor
-  // always has a source pad of the correct size
-  desc_stream << "videotestsrc is-live=true pattern=black ! video/x-raw,width="
-              << this->get_parameter("out_width").as_int()
-              << ",height=" << this->get_parameter("out_height").as_int()
-              << ",framerate=" << this->get_parameter("out_framerate").as_int()
-              << "/1 ! nvvidconv ! compositor.sink_0 ";
+  std::stringstream desc;
+  const int W = this->get_parameter("out_width").as_int();
+  const int H = this->get_parameter("out_height").as_int();
+  const int FPS = this->get_parameter("out_framerate").as_int();
+
+  // Dummy black source → tee → feeds both compositors (keeps them alive with
+  // no cameras and provides a fixed-size reference pad at sink_0)
+  desc << "videotestsrc is-live=true pattern=black "
+       << "! video/x-raw,width=" << W << ",height=" << H
+       << ",framerate=" << FPS << "/1 "
+       << "! nvvidconv ! tee name=t0 "
+       << "t0. ! queue leaky=downstream max-size-buffers=1 ! compositor.sink_0 "
+       << "t0. ! queue leaky=downstream max-size-buffers=1 ! mosaic_compositor.sink_0 ";
+
   size_t index = 1;
   std::vector<std::string> camera_name;
   this->get_parameter("camera_name", camera_name);
@@ -58,62 +65,72 @@ bool InputNode::create_pipeline() {
     CameraType type = static_cast<CameraType>(type_int);
 
     if (type == CameraType::TestSrc) {
-      desc_stream << "videotestsrc is-live=true name=" << name << " ! ";
+      desc << "videotestsrc is-live=true name=" << name << " ! ";
     } else if (type == CameraType::V4l2Src) {
       if (!std::filesystem::exists(path)) {
         RCLCPP_ERROR(this->get_logger(), "Camera path does not exist: %s",
                      path.c_str());
         continue;
       }
-      desc_stream << "v4l2src device=" << path << " name=" << name << " ! ";
+      desc << "v4l2src device=" << path << " name=" << name << " ! ";
       bool encoded;
       this->get_parameter(name + ".encoded", encoded);
       if (encoded) {
-        desc_stream << "jpegdec ! ";
+        desc << "jpegdec ! ";
       }
     } else {
       RCLCPP_WARN(this->get_logger(), "Unimplemented Type for camera: %s",
                   name.c_str());
       continue;
     }
+
     int cam_width = this->get_parameter(name + ".width").as_int();
     int cam_height = this->get_parameter(name + ".height").as_int();
     int cam_framerate = this->get_parameter(name + ".framerate").as_int();
     if (cam_width > 0 || cam_height > 0 || cam_framerate > 0) {
-      desc_stream << "video/x-raw,";
-      if (cam_width > 0) {
-        desc_stream << "width=" << cam_width << ",";
-      }
-      if (cam_height > 0) {
-        desc_stream << "height=" << cam_height << ",";
-      }
-      if (cam_framerate > 0) {
-        desc_stream << "framerate=" << cam_framerate << "/1,";
-      }
+      desc << "video/x-raw,";
+      if (cam_width > 0)
+        desc << "width=" << cam_width << ",";
+      if (cam_height > 0)
+        desc << "height=" << cam_height << ",";
+      if (cam_framerate > 0)
+        desc << "framerate=" << cam_framerate << "/1,";
       // Remove trailing comma
-      std::string current_desc = desc_stream.str();
-      if (current_desc.back() == ',') {
-        current_desc.pop_back();
-        desc_stream.str("");
-        desc_stream << current_desc << " ! ";
+      std::string s = desc.str();
+      if (s.back() == ',') {
+        s.pop_back();
+        desc.str("");
+        desc << s << " ! ";
       }
     }
 
-    desc_stream << "nvvidconv ! compositor.sink_" << index << " ";
+    // Split each camera via tee into both compositors
+    desc << "nvvidconv ! tee name=t" << index << " "
+         << "t" << index << ". ! queue leaky=downstream max-size-buffers=1 "
+         << "! compositor.sink_" << index << " "
+         << "t" << index << ". ! queue leaky=downstream max-size-buffers=1 "
+         << "! mosaic_compositor.sink_" << index << " ";
     source_map_.emplace(name, index);
     ++index;
   }
-  desc_stream << "nvcompositor name=compositor sink_0::alpha=0.0 ! ";
-  desc_stream << "nvvidconv ! videorate ! video/x-raw,width="
-              << this->get_parameter("out_width").as_int()
-              << ",height=" << this->get_parameter("out_height").as_int()
-              << ",framerate=" << this->get_parameter("out_framerate").as_int()
-              << "/1 ! interpipesink name=input";
 
-  RCLCPP_INFO(this->get_logger(), "Pipeline description: %s",
-              desc_stream.str().c_str());
+  // Stream 1 – operator compositor: layout is set dynamically via video_cb
+  desc << "nvcompositor name=compositor sink_0::alpha=0.0 ! "
+       << "nvvidconv ! videorate ! "
+       << "video/x-raw,width=" << W << ",height=" << H
+       << ",framerate=" << FPS << "/1 "
+       << "! interpipesink name=input ";
+
+  // Stream 2 – mosaic compositor: fixed grid layout set by set_mosaic_layout()
+  desc << "nvcompositor name=mosaic_compositor sink_0::alpha=0.0 ! "
+       << "nvvidconv ! videorate ! "
+       << "video/x-raw,width=" << W << ",height=" << H
+       << ",framerate=" << FPS << "/1 "
+       << "! interpipesink name=mosaic";
+
+  RCLCPP_INFO(this->get_logger(), "Pipeline description: %s", desc.str().c_str());
   GError *err = nullptr;
-  GstElement *p = gst_parse_launch(desc_stream.str().c_str(), &err);
+  GstElement *p = gst_parse_launch(desc.str().c_str(), &err);
   if (err || !p) {
     RCLCPP_ERROR(this->get_logger(), "gst_parse_launch failed: %s",
                  err ? err->message : "unknown");
@@ -128,10 +145,61 @@ bool InputNode::create_pipeline() {
   }
 
   pipeline_ = p;
+  set_mosaic_layout();
+
   if (current_video_request_) {
     video_cb(current_video_request_,
              std::make_shared<interfaces::srv::VideoOut::Response>());
   }
+  return true;
+}
+
+bool InputNode::set_mosaic_layout() {
+  const int n = static_cast<int>(source_map_.size());
+  if (n == 0)
+    return true;
+
+  GstElement *mosaic = get_element("mosaic_compositor");
+  if (!mosaic) {
+    RCLCPP_ERROR(this->get_logger(), "set_mosaic_layout: mosaic_compositor not found");
+    return false;
+  }
+
+  const int W = this->get_parameter("out_width").as_int();
+  const int H = this->get_parameter("out_height").as_int();
+  const int cols = static_cast<int>(std::ceil(std::sqrt(static_cast<double>(n))));
+  const int rows = (n + cols - 1) / cols;
+  const int cell_w = W / cols;
+  const int cell_h = H / rows;
+
+  int grid_i = 0;
+  for (const auto &[cam_name, sink_idx] : source_map_) {
+    const int col = grid_i % cols;
+    const int row = grid_i / cols;
+    const std::string pad_name = "sink_" + std::to_string(sink_idx);
+    GstPad *pad = gst_element_get_static_pad(mosaic, pad_name.c_str());
+    if (!pad) {
+      RCLCPP_WARN(this->get_logger(), "set_mosaic_layout: pad %s not found",
+                  pad_name.c_str());
+      ++grid_i;
+      continue;
+    }
+    g_object_set(G_OBJECT(pad),
+                 "xpos", col * cell_w,
+                 "ypos", row * cell_h,
+                 "width", cell_w,
+                 "height", cell_h,
+                 "alpha", 1.0,
+                 "zorder", grid_i,
+                 NULL);
+    gst_object_unref(pad);
+    ++grid_i;
+  }
+
+  gst_object_unref(mosaic);
+  RCLCPP_INFO(this->get_logger(),
+              "Mosaic layout: %d cameras, %d cols x %d rows, cell %dx%d px",
+              n, cols, rows, cell_w, cell_h);
   return true;
 }
 

--- a/src/Cameras/video_streaming/src/input_node.cpp
+++ b/src/Cameras/video_streaming/src/input_node.cpp
@@ -48,11 +48,11 @@ bool InputNode::create_pipeline() {
   // Dummy black source → tee → feeds both compositors (keeps them alive with
   // no cameras and provides a fixed-size reference pad at sink_0)
   desc << "videotestsrc is-live=true pattern=black "
-       << "! video/x-raw,width=" << W << ",height=" << H
-       << ",framerate=" << FPS << "/1 "
-       << "! nvvidconv ! tee name=t0 "
+       << "! video/x-raw,width=" << W << ",height=" << H << ",framerate=" << FPS
+       << "/1 " << "! nvvidconv ! tee name=t0 "
        << "t0. ! queue leaky=downstream max-size-buffers=1 ! compositor.sink_0 "
-       << "t0. ! queue leaky=downstream max-size-buffers=1 ! mosaic_compositor.sink_0 ";
+       << "t0. ! queue leaky=downstream max-size-buffers=1 ! "
+          "mosaic_compositor.sink_0 ";
 
   size_t index = 1;
   std::vector<std::string> camera_name;
@@ -105,10 +105,10 @@ bool InputNode::create_pipeline() {
     }
 
     // Split each camera via tee into both compositors
-    desc << "nvvidconv ! tee name=t" << index << " "
-         << "t" << index << ". ! queue leaky=downstream max-size-buffers=1 "
-         << "! compositor.sink_" << index << " "
-         << "t" << index << ". ! queue leaky=downstream max-size-buffers=1 "
+    desc << "nvvidconv ! tee name=t" << index << " " << "t" << index
+         << ". ! queue leaky=downstream max-size-buffers=1 "
+         << "! compositor.sink_" << index << " " << "t" << index
+         << ". ! queue leaky=downstream max-size-buffers=1 "
          << "! mosaic_compositor.sink_" << index << " ";
     source_map_.emplace(name, index);
     ++index;
@@ -116,19 +116,18 @@ bool InputNode::create_pipeline() {
 
   // Stream 1 – operator compositor: layout is set dynamically via video_cb
   desc << "nvcompositor name=compositor sink_0::alpha=0.0 ! "
-       << "nvvidconv ! videorate ! "
-       << "video/x-raw,width=" << W << ",height=" << H
-       << ",framerate=" << FPS << "/1 "
+       << "nvvidconv ! videorate ! " << "video/x-raw,width=" << W
+       << ",height=" << H << ",framerate=" << FPS << "/1 "
        << "! interpipesink name=input ";
 
   // Stream 2 – mosaic compositor: fixed grid layout set by set_mosaic_layout()
   desc << "nvcompositor name=mosaic_compositor sink_0::alpha=0.0 ! "
-       << "nvvidconv ! videorate ! "
-       << "video/x-raw,width=" << W << ",height=" << H
-       << ",framerate=" << FPS << "/1 "
+       << "nvvidconv ! videorate ! " << "video/x-raw,width=" << W
+       << ",height=" << H << ",framerate=" << FPS << "/1 "
        << "! interpipesink name=mosaic";
 
-  RCLCPP_INFO(this->get_logger(), "Pipeline description: %s", desc.str().c_str());
+  RCLCPP_INFO(this->get_logger(), "Pipeline description: %s",
+              desc.str().c_str());
   GError *err = nullptr;
   GstElement *p = gst_parse_launch(desc.str().c_str(), &err);
   if (err || !p) {
@@ -161,13 +160,15 @@ bool InputNode::set_mosaic_layout() {
 
   GstElement *mosaic = get_element("mosaic_compositor");
   if (!mosaic) {
-    RCLCPP_ERROR(this->get_logger(), "set_mosaic_layout: mosaic_compositor not found");
+    RCLCPP_ERROR(this->get_logger(),
+                 "set_mosaic_layout: mosaic_compositor not found");
     return false;
   }
 
   const int W = this->get_parameter("out_width").as_int();
   const int H = this->get_parameter("out_height").as_int();
-  const int cols = static_cast<int>(std::ceil(std::sqrt(static_cast<double>(n))));
+  const int cols =
+      static_cast<int>(std::ceil(std::sqrt(static_cast<double>(n))));
   const int rows = (n + cols - 1) / cols;
   const int cell_w = W / cols;
   const int cell_h = H / rows;
@@ -184,22 +185,17 @@ bool InputNode::set_mosaic_layout() {
       ++grid_i;
       continue;
     }
-    g_object_set(G_OBJECT(pad),
-                 "xpos", col * cell_w,
-                 "ypos", row * cell_h,
-                 "width", cell_w,
-                 "height", cell_h,
-                 "alpha", 1.0,
-                 "zorder", grid_i,
-                 NULL);
+    g_object_set(G_OBJECT(pad), "xpos", col * cell_w, "ypos", row * cell_h,
+                 "width", cell_w, "height", cell_h, "alpha", 1.0, "zorder",
+                 grid_i, NULL);
     gst_object_unref(pad);
     ++grid_i;
   }
 
   gst_object_unref(mosaic);
   RCLCPP_INFO(this->get_logger(),
-              "Mosaic layout: %d cameras, %d cols x %d rows, cell %dx%d px",
-              n, cols, rows, cell_w, cell_h);
+              "Mosaic layout: %d cameras, %d cols x %d rows, cell %dx%d px", n,
+              cols, rows, cell_w, cell_h);
   return true;
 }
 

--- a/src/Cameras/video_streaming/src/mosaic_webrtc_node.cpp
+++ b/src/Cameras/video_streaming/src/mosaic_webrtc_node.cpp
@@ -15,7 +15,8 @@ MosaicWebRtcNode::MosaicWebRtcNode(const rclcpp::NodeOptions &options)
     RCLCPP_FATAL(get_logger(), "MosaicWebRtcNode: failed to start pipeline.");
     throw std::runtime_error("MosaicWebRtcNode: pipeline start failed");
   }
-  RCLCPP_INFO(get_logger(), "MosaicWebRtcNode: pipeline started (signalling port %ld).",
+  RCLCPP_INFO(get_logger(),
+              "MosaicWebRtcNode: pipeline started (signalling port %ld).",
               this->get_parameter("signalling_port").as_int());
 }
 
@@ -32,13 +33,13 @@ bool MosaicWebRtcNode::create_pipeline() {
        << "videorate drop-only=true ! video/x-raw,framerate=" << framerate
        << "/1 ! nvvidconv ! "
        << "nvv4l2h264enc iframeinterval=1 insert-sps-pps=true control-rate=1 "
-       << "bitrate=" << bitrate << " ! "
-       << "h264parse config-interval=-1 ! "
+       << "bitrate=" << bitrate << " ! " << "h264parse config-interval=-1 ! "
        << "webrtcsink run-signalling-server=true "
        << "signalling-server-port=" << port << " "
        << "video-caps=\"video/x-h264\"";
 
-  RCLCPP_INFO(get_logger(), "MosaicWebRtcNode pipeline: %s", desc.str().c_str());
+  RCLCPP_INFO(get_logger(), "MosaicWebRtcNode pipeline: %s",
+              desc.str().c_str());
   GError *err = nullptr;
   GstElement *p = gst_parse_launch(desc.str().c_str(), &err);
   if (err || !p) {

--- a/src/Cameras/video_streaming/src/mosaic_webrtc_node.cpp
+++ b/src/Cameras/video_streaming/src/mosaic_webrtc_node.cpp
@@ -1,0 +1,62 @@
+#include "mosaic_webrtc_node.hpp"
+#include <rclcpp_components/register_node_macro.hpp>
+#include <sstream>
+
+namespace video_streaming {
+
+MosaicWebRtcNode::MosaicWebRtcNode(const rclcpp::NodeOptions &options)
+    : BaseVideoNode("mosaic_webrtc_node", options) {
+  // Allow the signalling port to be overridden at launch time.
+  this->declare_parameter<int>("signalling_port", 8444);
+  this->declare_parameter<int>("bitrate", 1000000);
+  this->declare_parameter<int>("framerate", 5);
+
+  if (!start_pipeline()) {
+    RCLCPP_FATAL(get_logger(), "MosaicWebRtcNode: failed to start pipeline.");
+    throw std::runtime_error("MosaicWebRtcNode: pipeline start failed");
+  }
+  RCLCPP_INFO(get_logger(), "MosaicWebRtcNode: pipeline started (signalling port %ld).",
+              this->get_parameter("signalling_port").as_int());
+}
+
+bool MosaicWebRtcNode::create_pipeline() {
+  const int port = this->get_parameter("signalling_port").as_int();
+  const int bitrate = this->get_parameter("bitrate").as_int();
+  const int framerate = this->get_parameter("framerate").as_int();
+  std::ostringstream desc;
+  // All-intra H.264 (iframeinterval=1): every frame is a keyframe, so the
+  // stream behaves like MJPEG (frame drops never corrupt the picture) while
+  // compressing better than JPEG. Encoding explicitly here instead of letting
+  // webrtcsink pick an encoder keeps the encoder settings under our control.
+  desc << "interpipesrc listen-to=mosaic is-live=true ! "
+       << "videorate drop-only=true ! video/x-raw,framerate=" << framerate
+       << "/1 ! nvvidconv ! "
+       << "nvv4l2h264enc iframeinterval=1 insert-sps-pps=true control-rate=1 "
+       << "bitrate=" << bitrate << " ! "
+       << "h264parse config-interval=-1 ! "
+       << "webrtcsink run-signalling-server=true "
+       << "signalling-server-port=" << port << " "
+       << "video-caps=\"video/x-h264\"";
+
+  RCLCPP_INFO(get_logger(), "MosaicWebRtcNode pipeline: %s", desc.str().c_str());
+  GError *err = nullptr;
+  GstElement *p = gst_parse_launch(desc.str().c_str(), &err);
+  if (err || !p) {
+    RCLCPP_ERROR(get_logger(), "gst_parse_launch failed: %s",
+                 err ? err->message : "unknown");
+    if (err)
+      g_error_free(err);
+    return false;
+  }
+  if (!GST_IS_PIPELINE(p)) {
+    RCLCPP_ERROR(get_logger(), "Parsed element is not a pipeline.");
+    gst_object_unref(p);
+    return false;
+  }
+
+  pipeline_ = p;
+  return true;
+}
+
+RCLCPP_COMPONENTS_REGISTER_NODE(video_streaming::MosaicWebRtcNode)
+} // namespace video_streaming

--- a/src/Cameras/video_streaming/src/mosaic_webrtc_node.cpp
+++ b/src/Cameras/video_streaming/src/mosaic_webrtc_node.cpp
@@ -29,11 +29,11 @@ bool MosaicWebRtcNode::create_pipeline() {
   // stream behaves like MJPEG (frame drops never corrupt the picture) while
   // compressing better than JPEG. Encoding explicitly here instead of letting
   // webrtcsink pick an encoder keeps the encoder settings under our control.
-  desc << "interpipesrc listen-to=mosaic is-live=true ! "
+  desc << "interpipesrc listen-to=mosaic is-live=true format=3 ! "
        << "videorate drop-only=true ! video/x-raw,framerate=" << framerate
-       << "/1 ! nvvidconv ! "
-       << "nvv4l2h264enc iframeinterval=1 insert-sps-pps=true control-rate=1 "
-       << "bitrate=" << bitrate << " ! " << "h264parse config-interval=-1 ! "
+       << "/1 ! nvvidconv ! nvv4l2h264enc iframeinterval=1 "
+       << "idrinterval=" << framerate << " insert-sps-pps=true control-rate=1 "
+       << "bitrate=" << bitrate << " ! "
        << "webrtcsink run-signalling-server=true "
        << "signalling-server-port=" << port << " "
        << "video-caps=\"video/x-h264\"";


### PR DESCRIPTION
This PR adds a second independent video output that streams a mosaic view of all connected cameras via WebRTC, separate from the existing operator view.

**Dual compositor pipeline**: Each camera source is now split via tee and fed into two compositors in parallel : 
the existing compositor (operator view, dynamically controlled via video_cb) and a new mosaic_compositor (fixed grid layout)


**Automatic grid layout**: Added set_mosaic_layout(), which computes a near-square grid (columns/rows) based on the number of active cameras and sets each pad's xpos, ypos, width, and height accordingly


**New MosaicWebRtcNode:** Reads the mosaic feed via interpipesrc, encodes it with nvv4l2h264enc using all-intra encoding (iframeinterval=1) so frame drops don't corrupt the picture (similar robustness to MJPEG, but better compression), and streams it out via webrtcsink with its own signalling server (default port 8444)