### PR TITLE
feat: disable unnecessary collision checking

### DIFF
--- a/src/Arm/arm_control/config/rover_urdf.srdf
+++ b/src/Arm/arm_control/config/rover_urdf.srdf
@@ -138,8 +138,6 @@
     <disable_collisions link1="Frame" link2="Wheel_Arm_Back_Right" reason="Never"/>
     <disable_collisions link1="Frame" link2="Wheel_Arm_Front_Right" reason="Never"/>
     <disable_collisions link1="Frame" link2="Zed" reason="Adjacent"/>
-    <disable_collisions link1="Frame" link2="Wheel_Front_Left" reason="Default"/>
-    <disable_collisions link1="Frame" link2="Wheel_Front_Right" reason="Default"/>
     <disable_collisions link1="GPS_Left" link2="GPS_Right" reason="Never"/>
     <disable_collisions link1="GPS_Left" link2="Link_1" reason="Never"/>
     <disable_collisions link1="GPS_Left" link2="Link_2" reason="Never"/>
@@ -319,4 +317,16 @@
     <disable_collisions link1="Wheel_Front_Left" link2="Wheel_Front_Right" reason="Never"/>
     <disable_collisions link1="Wheel_Front_Left" link2="Zed" reason="Never"/>
     <disable_collisions link1="Wheel_Front_Right" link2="Zed" reason="Never"/>
+
+    <!-- Manually Disable collision checking between 2 chassis objects since only the arm does collision checking -->
+    <disable_collisions link1="Frame" link2="Wheel_Arm_Back_Left" reason="Default"/>
+    <disable_collisions link1="Frame" link2="Wheel_Arm_Front_Left" reason="Default"/>
+    <disable_collisions link1="Frame" link2="Wheel_Back_Left" reason="Default"/>
+    <disable_collisions link1="Frame" link2="Wheel_Back_Right" reason="Default"/>
+    <disable_collisions link1="Frame" link2="Wheel_Front_Left" reason="Default"/>
+    <disable_collisions link1="Frame" link2="Wheel_Front_Right" reason="Default"/>
+    <disable_collisions link1="GPS_Left" link2="Sus_Arm_Back_Left" reason="Default"/>
+    <disable_collisions link1="GPS_Left" link2="Sus_Arm_Front_Left" reason="Default"/>
+    <disable_collisions link1="GPS_Right" link2="Sus_Arm_Back_Right" reason="Default"/>
+    <disable_collisions link1="GPS_Right" link2="Sus_Arm_Front_Right" reason="Default"/>
 </robot>


### PR DESCRIPTION
Some changes from last night.

Disabling collision checking from any 2 non-arm links. The arm software slows down whenever a collision is near - even if the collision has nothing to do with the arm.

Apparently the URDF collision matrix is not good enough to have these links disabled when I auto generated this file. The urdf links must be slightly larger in software than real life.