### PR TITLE
Windows dev container GUI support + missing rover_urdf view.rviz

### DIFF
--- a/.devcontainer/windows-gui/devcontainer.json
+++ b/.devcontainer/windows-gui/devcontainer.json
@@ -1,0 +1,39 @@
+{
+  "name": "CPRT Dev Container (Windows Host + GUI)",
+  "image": "cprtsoftware/rover:dev-amd64",
+
+  // GUI support via WSLg. Unlike the Linux configs, the X11 socket cannot be
+  // mounted from /tmp/.X11-unix: that path is a WSLg tmpfs inside the user's
+  // WSL distro, but the Docker daemon resolves mount sources against its own
+  // filesystem (the docker-desktop distro), where it does not exist. Docker
+  // Desktop exposes the host's WSLg socket inside the VM at the path below.
+  // DISPLAY is hardcoded because WSLg always serves :0, and ${localEnv:DISPLAY}
+  // does not resolve to the WSL value from a Dev Containers window.
+  "runArgs": [
+    "--env", "DISPLAY=:0",
+    "--volume", "/run/desktop/mnt/host/wslg/.X11-unix:/tmp/.X11-unix:rw"
+  ],
+  "mounts": [
+  ],
+  "containerEnv": {
+    "SSH_AUTH_SOCK": "/ssh-agent",
+    "NVIDIA_VISIBLE_DEVICES": "all",
+    "NVIDIA_DRIVER_CAPABILITIES": "all"
+  },
+
+  "remoteUser": "vscode",
+  "containerUser": "vscode",
+  "remoteEnv": {
+    "USER": "vscode"
+  },
+
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
+      },
+      "extensions": [ "ms-vscode.cpptools", "ms-azuretools.vscode-docker" ]
+    }
+  },
+  "postCreateCommand": "echo 'source /opt/ros/humble/setup.bash' >> ~/.bashrc"
+}

--- a/.devcontainer/windows-gui/devcontainer.json
+++ b/.devcontainer/windows-gui/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "CPRT Dev Container (Windows Host + GUI)",
-  "image": "cprtsoftware/rover:dev-amd64",
+  "image": "cprtsoftware/rover:dev-lite",
 
   // GUI support via WSLg. Unlike the Linux configs, the X11 socket cannot be
   // mounted from /tmp/.X11-unix: that path is a WSLg tmpfs inside the user's
@@ -21,10 +21,10 @@
     "NVIDIA_DRIVER_CAPABILITIES": "all"
   },
 
-  "remoteUser": "vscode",
-  "containerUser": "vscode",
+  "remoteUser": "ubuntu",
+  "containerUser": "ubuntu",
   "remoteEnv": {
-    "USER": "vscode"
+    "USER": "ubuntu"
   },
 
   "customizations": {
@@ -35,5 +35,5 @@
       "extensions": [ "ms-vscode.cpptools", "ms-azuretools.vscode-docker" ]
     }
   },
-  "postCreateCommand": "echo 'source /opt/ros/humble/setup.bash' >> ~/.bashrc"
+  "postCreateCommand": "echo 'source /opt/ros/jazzy/setup.bash' >> ~/.bashrc"
 }

--- a/src/URDF/rover_urdf/rviz/view.rviz
+++ b/src/URDF/rover_urdf/rviz/view.rviz
@@ -1,0 +1,300 @@
+Panels:
+  - Class: rviz_common/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /Grid1
+        - /RobotModel1
+      Splitter Ratio: 0.5
+    Tree Height: 555
+  - Class: rviz_common/Selection
+    Name: Selection
+  - Class: rviz_common/Tool Properties
+    Expanded:
+      - /2D Goal Pose1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz_common/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz_common/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz_default_plugins/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Alpha: 1
+      Class: rviz_default_plugins/RobotModel
+      Collision Enabled: false
+      Description File: ""
+      Description Source: Topic
+      Description Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /robot_description
+      Enabled: true
+      Links:
+        All Links Enabled: true
+        Antenna_Back:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        Antenna_Front:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        EndEffector:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        Frame:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        GPS_Left:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        GPS_Right:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        Link Tree Style: Links in Alphabetic Order
+        Link_1:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        Link_2:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        Link_3:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        Link_4:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        Link_5:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        Link_6:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        Rocker_Left:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        Rocker_Right:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        Sus_Arm_Back_Left:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        Sus_Arm_Back_Right:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        Sus_Arm_Front_Left:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        Sus_Arm_Front_Right:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        Wheel_Arm_Back_Left:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        Wheel_Arm_Back_Right:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        Wheel_Arm_Front_Left:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        Wheel_Arm_Front_Right:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        Wheel_Back_Left:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        Wheel_Back_Right:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        Wheel_Front_Left:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        Wheel_Front_Right:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        Zed:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        base_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+      Mass Properties:
+        Inertia: false
+        Mass: false
+      Name: RobotModel
+      TF Prefix: ""
+      Update Interval: 0
+      Value: true
+      Visual Enabled: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Fixed Frame: base_link
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz_default_plugins/Interact
+      Hide Inactive Objects: true
+    - Class: rviz_default_plugins/MoveCamera
+    - Class: rviz_default_plugins/Select
+    - Class: rviz_default_plugins/FocusCamera
+    - Class: rviz_default_plugins/Measure
+      Line color: 128; 128; 0
+    - Class: rviz_default_plugins/SetInitialPose
+      Covariance x: 0.25
+      Covariance y: 0.25
+      Covariance yaw: 0.06853891909122467
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /initialpose
+    - Class: rviz_default_plugins/SetGoal
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /goal_pose
+    - Class: rviz_default_plugins/PublishPoint
+      Single click: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /clicked_point
+  Transformation:
+    Current:
+      Class: rviz_default_plugins/TF
+  Value: true
+  Views:
+    Current:
+      Class: rviz_default_plugins/Orbit
+      Distance: 3.4638402462005615
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 0.14458782970905304
+        Y: -0.059284139424562454
+        Z: -0.10198041051626205
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.6053978800773621
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 4.253584384918213
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 846
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd000000040000000000000156000002b4fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003b000002b4000000c700fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f000002b4fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003b000002b4000000a000fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000004b00000003efc0100000002fb0000000800540069006d00650100000000000004b00000025300fffffffb0000000800540069006d006501000000000000045000000000000000000000023f000002b400000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1200
+  X: 1809
+  Y: 362


### PR DESCRIPTION
Tested the dev container setup on Windows per Connor's request in discord. The
linux-lite-gui display args don't port over directly — Windows needs a
different mount path.

## Why the Linux args don't work on Windows

`/tmp/.X11-unix` is a WSLg tmpfs inside the user's WSL distro. The Docker
daemon runs in the separate `docker-desktop` distro and resolves mount
sources against *its own* filesystem, where that path doesn't exist. Docker's
response to a missing mount source is to silently create an empty directory
and mount that — so the container gets `/tmp/.X11-unix` with no `X0` socket
and no error anywhere.

Verified side by side:

```
docker run --rm -v /tmp/.X11-unix:/tmp/.X11-unix <img> ls /tmp/.X11-unix
  -> empty

docker run --rm -v /run/desktop/mnt/host/wslg/.X11-unix:/tmp/.X11-unix <img> ls /tmp/.X11-unix
  -> X0
```

`/run/desktop/mnt/host/wslg` is where Docker Desktop exposes the host's WSLg
socket inside its VM — reachable by the daemon.

Also `${localEnv:DISPLAY}` resolves to `1` (not `:0`) from a Dev Containers
window, so it's hardcoded to `:0`. WSLg always serves `:0`.

`.devcontainer/windows-gui/devcontainer.json` is a copy of the existing
`windows` config plus those two runArgs. Device mounts are deliberately
omitted since those host paths don't exist on Windows.

## Second commit: missing view.rviz

Unrelated, happy to split into its own PR if preferred.

`rover_urdf/launch/launch.py` defaults `rviz_config_file` to
`share/rover_urdf/rviz/view.rviz`, but that file has never existed in the
repo. `setup.py` globs `rviz/*`, which returns an empty list and silently
installs nothing — so RViz gets a path to a nonexistent file and falls back
to its built-in defaults (Fixed Frame `map`, which nothing publishes without
Nav2, and no RobotModel display). `use_rviz:=True` has always opened to a
blank grid with a frame error.

Adds the config with Fixed Frame `base_link` and RobotModel on
`/robot_description`. `setup.py` already had the install rule.

## Testing

Windows 11 + WSL2 + Docker Desktop, RTX 5060. RViz reports
`OpenGl version: 4.5 (GLSL 4.5)` and renders the rover URDF at ~31fps with
joint_state_publisher_gui driving the arm. No external X server (no VcXsrv).

Opened from a fork — I don't have push access to CPRT/rover.