### PR TITLE
fix: missing nvidia dep in base

### DIFF
--- a/docker/Dockerfile.base
+++ b/docker/Dockerfile.base
@@ -179,6 +179,7 @@ RUN if [ "$USE_NVIDIA" = "true" ]; then \
 # Stage 5: Minimal Runtime Base
 ############################
 FROM ros2-base AS runtime
+ARG USE_NVIDIA=true
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 WORKDIR /
@@ -205,6 +206,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gstreamer1.0-libav \
     gstreamer1.0-nice \
     && rm -rf /var/lib/apt/lists/*
+
+RUN if [ "$USE_NVIDIA" = "true" ]; then \
+        apt-get update && apt-get install -y --no-install-recommends \
+            libnvinfer10 libnvinfer-plugin10 libnvonnxparsers10 \
+        && rm -rf /var/lib/apt/lists/*; \
+    else \
+        echo "Skipping NVIDIA dependencies installation"; \
+    fi
 
 RUN source /opt/ros/$ROS_DISTRO/setup.bash \
     && rosdep init \

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -37,7 +37,6 @@ ARG CUDA_MINOR=3
 RUN apt-get update && apt-get install -y --no-install-recommends \
         cuda-compiler-${CUDA_MAJOR}-${CUDA_MINOR} \
         cuda-cudart-dev-${CUDA_MAJOR}-${CUDA_MINOR} \
-        libnvinfer10 libnvinfer-plugin10 libnvonnxparsers10 \
     && rm -rf /var/lib/apt/lists/*
 RUN groupadd -f zed && usermod -aG zed ubuntu
 RUN chmod -R a+r /usr/local/lib/python3.12/dist-packages/


### PR DESCRIPTION
Caught a missing dependancy for video streaming in our base image. Our dev image had it which is why it took so long for me to notice