### PR TITLE
fix: use new docker tag on start rover script

### DIFF
--- a/setup/start_rover.sh
+++ b/setup/start_rover.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 sudo enablecan.sh
 
+ROVER_DOCKER_IMAGE=cprtsoftware/rover:latest
+
  disco_server_id=$(docker ps -q -f name=disco-server)
  if [ -z "$disco_server_id" ]; then
      echo "Starting the discovery server..."
@@ -9,7 +11,7 @@ sudo enablecan.sh
         --ipc=host \
         -v /var/run/docker.sock:/var/run/docker.sock \
         --name disco-server \
-        cprtsoftware/rover:arm64 \
+        $ROVER_DOCKER_IMAGE \
         fastdds discovery -i 0 -p 11811
 else
     echo "Discovery server is already running."
@@ -24,7 +26,7 @@ if [ -z "$web_server_id" ]; then
         --name web-server \
         --env ROS_DISCOVERY_SERVER=192.168.0.55:11811 \
         --env ROS_SUPER_CLIENT=TRUE \
-        cprtsoftware/rover:arm64 \
+        $ROVER_DOCKER_IMAGE \
         ros2 launch rosbridge_server rosbridge_websocket_launch.xml
 else
     echo "Web server is already running."


### PR DESCRIPTION
This pull request updates the `setup/start_rover.sh` script to improve how the Docker image is referenced for starting the `disco-server` and `web-server` containers. The main change is centralizing the Docker image name in a variable, making it easier to update and maintain.

**Docker image reference improvements:**

* Introduced a `ROVER_DOCKER_IMAGE` variable at the top of `start_rover.sh` to define the Docker image name and tag (`cprtsoftware/rover:latest`).
* Updated the `docker run` commands for both the `disco-server` and `web-server` containers to use the new `ROVER_DOCKER_IMAGE` variable instead of hardcoding the image name. [[1]](diffhunk://#diff-2729825cce3c94a941bbad1caa46e217c85d5d8d013ac4c3cdd3fcef027b7db6L12-R14) [[2]](diffhunk://#diff-2729825cce3c94a941bbad1caa46e217c85d5d8d013ac4c3cdd3fcef027b7db6L27-R29)