### PR TITLE
feat: add headlights to usb servo controller

### DIFF
--- a/src/HW-Devices/servo_pkg/config/usb_controller.yaml
+++ b/src/HW-Devices/servo_pkg/config/usb_controller.yaml
@@ -19,3 +19,14 @@ USB_Servo_node:
       min: 350.0
       max: 2500.0
       rom: 6.2832
+    # Headlight control
+    servo4:
+      name: "right_headlight"
+      min: 0.0
+      max: 20000.0
+      rom: 1.0
+    servo5:
+      name: "left_headlight"
+      min: 0.0
+      max: 20000.0
+      rom: 1.0


### PR DESCRIPTION
Elec does not want another board in the elec box. I do not blame them. Although it will flicker a little bit we want to try driving the LEDs via PWM from the servo controller. 20000 micro seconds = 20ms = 50hz = 100 duty cycle. A bit of a hack but I have seen worse. 

Any chance @codeflight1 can test it for me since I didn't want to disrupt Jack's practice last night. I'll be in at 6 otherwise. Pretty low risk change so I would like to get it merged in and built before tonight.